### PR TITLE
add an exception on space before comma when not refering to columns only...

### DIFF
--- a/style.rmd
+++ b/style.rmd
@@ -122,6 +122,13 @@ x[1,]   # Needs a space after the comma
 x[1 ,]  # Space goes after comma not before
 ```
 
+As a small exception you can use one space if you are not refering to any rows.
+
+```
+# Good
+diamonds[ , 5]
+```
+
 ### Curly braces
 
 An opening curly brace should never go on its own line and should always be followed by a new line. A closing curly brace should always go on its own line, unless it's followed by `else`.


### PR DESCRIPTION
... using square brackets

I have previously red your style guide, and I have taken almost everything to heart.

My exception is that I think this improves legibility, since readers often get confused between rows and columns, this helps avoid confusiong a little bit.

and:

I assign the copyright of this contribution to Hadley Wickham
