### PR TITLE
added install instruction for BiocInstaller

### DIFF
--- a/intro.rmd
+++ b/intro.rmd
@@ -60,6 +60,12 @@ During the development of the book, you'll probably also want the development ve
 devtools::install_github("hadley/devtools")
 ```
 
+Note that you might need to install the [BiocInstaller](www.bioconductor.org/install/) package before being able to install the development version of devtools, this can be done via:
+
+```{r, eval = FALSE}
+source("http://bioconductor.org/biocLite.R")
+```
+
 You'll also need to make sure you have a C compiler and other need command line tools. If you're on windows or the mac, Rstudio will install these for you if you don't have them already. Otherwise:
 
 * On Windows, download and install [Rtools](http://cran.r-project.org/bin/windows/Rtools/). NB: this is not an R package!


### PR DESCRIPTION
BiocInstaller seems to be needed to install the development version of the devtools package. Added a correspeonding sentence.
I assign the copyright of this contribution to Hadley Wickham.
