### PR TITLE
Update style.rmd regarding word separators

### DIFF
--- a/style.rmd
+++ b/style.rmd
@@ -19,8 +19,8 @@ The formatR package, by Yihui Xie, makes it easier to clean up poorly formatted 
 File names should be meaningful and end in `.R`.
 
     # Good
-    fit-models.R
-    utility-functions.R
+    fit_models.R
+    utility_functions.R
 
     # Bad
     foo.r
@@ -28,9 +28,9 @@ File names should be meaningful and end in `.R`.
 
 If files need to be run in sequence, prefix them with numbers:
 
-    0-download.R
-    1-parse.R
-    2-explore.R
+    0_download.R
+    1_parse.R
+    2_explore.R
 
 Pay attention to capitalization, since you, or some of your collaborators, might be using an operating system with a case-insensitive file system (e.g., Microsoft Windows) which can lead to problems with (case-sensitive) revision control systems. Never use filenames that differ only in capitalisation.
 


### PR DESCRIPTION
Changed the example file names in lines 22-23 and lines 31-33.  Replaced the dashes with underscores, since line 44 suggests using underscores to separate words within a name.
