### PR TITLE
Package `Title` must be title case

### DIFF
--- a/description.rmd
+++ b/description.rmd
@@ -11,7 +11,7 @@ The job of the `DESCRIPTION` file is to store important metadata about your pack
 Every package must have a `DESCRIPTION`. In fact, it's the defining feature of a package (RStudio and devtools consider any directory containing `DESCRIPTION` to be a package). To get you started, `devtools::create("mypackage")` automatically adds a bare-bones description file. This will allow you to start writing package without having to worry about the metadata until you need to. The minimal description will vary a bit depending on your settings, but should look something like this:
 
     Package: mypackage
-    Title: What the package does (one line)
+    Title: What The Package Does (one line, title case required)
     Version: 0.1
     Authors@R: "First Last <first.last@example.com> [aut, cre]"
     Description: What the package does (one paragraph)


### PR DESCRIPTION
CRAN requires the package `Title` field to be title case; text should note this.
