### PR TITLE
Fixing typo

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -293,7 +293,7 @@ You can specify additional options to control the details of the rendering: ````
   block at the start of my document.
 
         ```{r, echo = FALSE}
-        knitr::opts_chunk$set(collapse = TRUE, comment = "#">)
+        knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
         ```
 
 *   `results = "asis"`. Treat the output of your R code as literal markdown.


### PR DESCRIPTION
change comment = "#"> to comment = "#>"
