### PR TITLE
demo.Rmd: missing word in "instead write vignette"

### DIFF
--- a/demo.Rmd
+++ b/demo.Rmd
@@ -17,7 +17,7 @@ You list and access demos with `demo()`:
 
 Each demo must be listed in `demo/00Index` in the form: `demo-name  Demo description`. The demo name is the name of the file without extension, e.g. `demo/my-demo.R` becomes `my-demo`.
 
-Generally, I do not recommend using demos. Instead write vignette:
+Generally, I do not recommend using demos. Instead write a vignette:
 
 * Demos are not automatically run by `R CMD check`. This means that they're
   not tested automatically, so can easily break without you realising.


### PR DESCRIPTION
Should be "instead write a vignette" or maybe "instead write vignettes".

(The lamest PR ever.)

I fully agree about vignettes vs demos. demos are vestigial. (There was a time before vignettes.)
