### PR TITLE
Clarify spacing for right parentheses.

### DIFF
--- a/style.rmd
+++ b/style.rmd
@@ -92,7 +92,7 @@ x <- 1 : 10
 base :: get
 ```
 
-Place a space before left parentheses, except in a function call.
+Place a space before left parentheses, except in a function call.  Always put a space after right parentheses.
 
 ```{r, eval = FALSE}
 # Good


### PR DESCRIPTION
You did not have any rule for what to do after right parentheses, however your examples clearly show you expect there to always be a space after right parentheses.

"I assign the copyright of this contribution to Hadley Wickham".
