### PR TITLE
Don't cuddle `else`

### DIFF
--- a/style.rmd
+++ b/style.rmd
@@ -128,7 +128,7 @@ x[1 ,]  # Space goes after comma not before
 
 ### Curly braces
 
-An opening curly brace should never go on its own line and should always be followed by a new line. A closing curly brace should always go on its own line, unless it's followed by `else`.
+An opening curly brace should never go on its own line and should always be followed by a new line. A closing curly brace should always go on its own line.
 
 Always indent the code inside curly braces.
 
@@ -141,7 +141,8 @@ if (y < 0 && debug) {
 
 if (y == 0) {
   log(x)
-} else {
+}
+else {
   y ^ x
 }
 
@@ -152,8 +153,7 @@ message("Y is negative")
 
 if (y == 0) {
   log(x)
-} 
-else {
+} else {
   y ^ x
 }
 ```


### PR DESCRIPTION
I realize this is your personal style, so you are welcome to reject this change, but I wanted to provide some arguments against promoting cuddled `else`.  I used to use cuddled `else` as well until I was persuaded otherwise.

First the argument for a cuddled `else` is that it saves a line of whitespace.  While this is a nice thing in general, with modern monitors you generally have a lot of vertical space to work with.

However cuddled `else` has the following readability drawbacks.  It no longer maintains vertical alignment with the controlling `if`, nor with it's own closing bracket.  This makes it more difficult to identify what controlling expression goes with which block.

It is also more difficult to distinguish the `else` block visually, because you lose the left-brace only line as a separator.  This makes it more difficult to visually 'chunk' the code.

A minor practical benefit to un-cuddled `else` is that you can easily comment out the `else` by simply commenting out the block.  With cuddled `else` you have to move the else to a new line before commenting.  This benefit is more pronounced when you would like to comment individual nested `if-else` constructs.

``` r
if (test) {
  body
}
#else if (test2) {
#  body2
#}
else {
  body3
}
```

If you were using cuddled `else` in the above code you would have to manually edit all three of the blocks, rather than simply commenting out the middle one.

I took most of these arguments from [Damian Conways 'Perl Best Practices'](http://books.google.com/books?id=gJf9tI2mytIC&lpg=PT46&dq=perl%20best%20practices%20Don%E2%80%99t%20cuddle%20an%20else&pg=PT46#v=onepage&q=perl%20best%20practices%20Don%E2%80%99t%20cuddle%20an%20else&f=false), which is what finally convinced me that un-cuddled `else` was preferable (for me at least).

I assign the copyright of this contribution to Hadley Wickham.
