### PR TITLE
Correcting yaml

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -78,7 +78,14 @@ I normally structure my `README` as follows:
 
 If you include an example in your `README` (a good idea!) you may want to generate it with Rmarkdown. Use these tips to make it as easy as possible:
 
-* Use `format: md_document` in the yaml metadata to output a markdown file.
+* Use the following yaml block to output a markdown file.
+  ```
+  ---
+  output:
+    md_document:
+      variant: markdown_github
+  ---
+  ```
 
 * Add `README.Rmd` to `.Rbuildignore` with 
   `devtools::add_ignore_file("README.Rmd")`.


### PR DESCRIPTION
putting `format: md_document` did not do anything for me, I believe the correct yaml field to output a github flavored markdown document is.

```

---
output:
  md_document:
    variant: markdown_github

---
```

The best way I can see to ensure the README.md gets regenerated would be to use a git post-commit hook that checks if the previous commit changed README.Rmd, if so run `render` on README.Rmd, stage the new README.md file and git commit --amend it to the just-ran commit.

Haven't actually tried to write the above hook to make sure it works though!
