### PR TITLE
add note on "pander" and "asis"

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -328,6 +328,10 @@ You can specify additional options to control the details of the rendering: ````
     
          4.7            3.2           1.3            0.2     
     ---------------------------------------------------------
+    
+    Although when using the `pander` generic S3 method instead of 
+    directly calling `pandoc.table`, specifying the `asis` options is
+    not needed any more.
 
 * `fig.show = "hold"` holds all figures until the end of the code block.
 


### PR DESCRIPTION
When using the generic S3 method, the "asis" chunk option is not needed any more: http://blog.rapporter.net/2014/09/pander-tables-inside-of-knitr.html

This might be useful for someone working on the documentation, as IMHO it's not a good practice to call `pandoc.table` directly.

---

Although please feel free to close this pull request without merging if you do not think this comment is useful here.
