### PR TITLE
Fixed typo

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -377,7 +377,7 @@ Organise your `NEWS.md` as follows:
 * Each change should be included in a bulleted list. If you have a lot of 
   changes you might want to break them up using subheadings, `## Major changes`,
   `## Bug fixes` etc. I usually stick with a simple list until just before
-  releasing the package when I'll reorgnise into sections, if needed.
+  releasing the package when I'll reorganise into sections, if needed.
   It's hard to know in advance exactly what sections you'll need.
 
 * If an item is related to an issue in github, include the issue number in


### PR DESCRIPTION
Found another typo. Also, quick question -- on that same page, the directions state to use `devtools::add_build_ignore`, but that function doesn't appear to be available...
