### PR TITLE
Point out trifle.

### DIFF
--- a/r.rmd
+++ b/r.rmd
@@ -41,7 +41,7 @@ To get started with your new package in RStudio, double-click the `pkgname.Rproj
 
 *   You get useful keyboard shortcuts for common package development tasks.
     You'll learn about them throughout the book. But to see them all, press 
-    Alt + Shift + K or use the Help | Keyboard shortcuts menu.
+    Alt + Shift + K (for Windows and Linux) Option + Shift + K (for Mac) or use the Help | Keyboard shortcuts menu.
     
     ```{r, echo = FALSE}
     bookdown::embed_png("screenshots/keyboard-shortcuts.png")
@@ -86,7 +86,7 @@ The first advantage of using a package is that it's easy to re-load your code. T
 * `devtools::load_all()`, reloads all code in the package. In RStudio access via __Cmd + Shift + L__,  
   which also saves all open files, saving you a keystroke.
 
-* Build & reload, only available in RStudio via __Cmd + Shift + B__. This installs the package, restarts R, and then reloads the package with 
+* Build and reload, only available in RStudio via __Cmd + Shift + B__. This installs the package, restarts R, and then reloads the package with 
   `library()` (doing this by hand is painful).
 
 These commands lead to a fluid development workflow:


### PR DESCRIPTION
Note that shortcuts for Mac. I think that it good to put a link to [RStudio
Support](https://support.rstudio.com/hc/en-us/articles/200711853-Keyboar
d-Shortcuts). unification for symbol (& -> and... in this document).