### PR TITLE
Fixing typos

### DIFF
--- a/intro.rmd
+++ b/intro.rmd
@@ -18,7 +18,7 @@ You already know how to use packages:
 
 The goal of this book is to teach you how to develop packages so that you can write your own, not just use other people's. Why write a package? One compelling reason is that you have code that you want to share with others. Bundling your code into a package makes it easy for other people to use it because packages are familiar. If your code is a package, any R user can easily download it, install it and learn how to use it with the documentation.
 
-But packages are useful even if you never share your code. As Hilary Parker says in her [introduction to packages](http://hilaryparker.com/2014/04/29/writing-an-r-package-from-scratch/): "Seriously, it doesn't have to be about sharing your code (although that is an added benefit!). It is about saving yourself time." Organising code in a package makes your life easier because packages come with conventions: you put R code in the `R/`, you put tests in `test/`, you put data in `data/` and so on. These conventions are helpful because:
+But packages are useful even if you never share your code. As Hilary Parker says in her [introduction to packages](http://hilaryparker.com/2014/04/29/writing-an-r-package-from-scratch/): "Seriously, it doesn't have to be about sharing your code (although that is an added benefit!). It is about saving yourself time." Organising code in a package makes your life easier because packages come with conventions: you put R code in the `R/`, you put tests in `tests/`, you put data in `data/` and so on. These conventions are helpful because:
 
 * They save you time --- you don't need to think about the best way to organise
   a project, you can just follow a template.
@@ -28,7 +28,7 @@ But packages are useful even if you never share your code. As Hilary Parker says
 
 It's even possible to use packages to structure your data analyses, as Robert M Flight discusses in a [series of blog posts](http://rmflight.github.io/posts/2014/07/analyses_as_packages.html). 
 
-The most accurate resource for up-to-date details on package development will always the official [writing R extensions][r-ext] mqnuql. However, this manual can be hard to understand if you're not already familiar with the basics of packages. It's also exhaustive, covering every possible package component, rather than focussing on the most common and useful components, as this book does. Writing R extensions is a useful resource once you've mastered the basics and need to check more esoteric details.
+The most accurate resource for up-to-date details on package development will always the official [writing R extensions][r-ext] manual. However, this manual can be hard to understand if you're not already familiar with the basics of packages. It's also exhaustive, covering every possible package component, rather than focussing on the most common and useful components, as this book does. Writing R extensions is a useful resource once you've mastered the basics and need to check more esoteric details.
 
 ## Philosophy {#intro-phil}
 


### PR DESCRIPTION
Path to `tests` directory changed from `test` to `tests` and `mqnuql` to `manual`

I assign the copyright of this contribution to Hadley Wickham
