### PR TITLE
Update vignettes.rmd to explicitely mention the `build_vignettes = TRUE` option.

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -400,7 +400,7 @@ Common problems:
 *   Everything works interactively, but the vignette doesn't show up after 
     you've installed the package. One of the following may have occurred. First, 
     because RStudio's "build and reload" doesn't build vignettes, you may need 
-    to run `devtools::install()` instead. Next check:
+    to run `devtools::install()` instead (where you can use the option `build_vignettes = TRUE`). Next check:
   
     1. The directory is called `vignettes/` and not `vignette/`.
 


### PR DESCRIPTION
Maybe it helps to explicitely point out that you need to use `build_vignettes = TRUE` with `devtools::install()`.

When I was missing my freshly written vignette in my package after using RStudio's "build and reload", I first ran the function without the option and was still missing the vignette. Only after I had checked the other three suggestions did I take a closer look at `devtools::install()` and noticed the option...