### PR TITLE
fixed two typos

### DIFF
--- a/check.rmd
+++ b/check.rmd
@@ -6,7 +6,7 @@ output: bookdown::html_chapter
 
 # Automated checking {#check}
 
-An import part of the package development process is `R CMD check`. `R CMD check` automatically checks your code for common problems. It's essential if you're planning on submitting to CRAN, but it's useful even if you're not because it automatically detects many commons problems that you'd otherwise discover the hard way.
+An important part of the package development process is `R CMD check`. `R CMD check` automatically checks your code for common problems. It's essential if you're planning on submitting to CRAN, but it's useful even if you're not because it automatically detects many commons problems that you'd otherwise discover the hard way.
 
 `R CMD check` will be frustrating the first time you run it - you'll discover many problems that need to be fixed. The key to making `R CMD check` less frustrating is to actually run it more often: the sooner you find a problem, the easier it is to fix. The upper limit of this approach is to run `R CMD check` every time you make a change. If you use GitHub, you'll learn precisely how to do that with [Travis-CI](#travis).
 

--- a/misc.rmd
+++ b/misc.rmd
@@ -9,7 +9,7 @@ output: bookdown::html_chapter
 There are three other directories that are valid top-level directories. They are rarely used:
 
 * `demo/`: for package demos. These were useful prior to the introduction
-  of vignettes, but are no longer recommend. See below.
+  of vignettes, but are no longer recommended. See below.
 
 * `exec/`: for executable scripts. Compared to other directories, files in 
   `exec/` are automatically flagged as executable.


### PR DESCRIPTION
Also, the word "focussed" is used twice in the text. At first I thought this was a typo because I've never seen it spelled like that but it's correct. However, most style guides I've consulted suggest using only the single 's' variety. Should I make a pull request to s/focussed/focused/g ?