### PR TITLE
'alternative documentation workflow' _will_ show links

### DIFF
--- a/man.rmd
+++ b/man.rmd
@@ -91,7 +91,7 @@ bookdown::embed_png("screenshots/man-add.png", dpi = 220)
 
 ## Alternative documentation workflow {#man-workflow-2}
 
-The first documentation workflow is very fast, but it has one limitation: the preview documentation pages will show any links between pages. If you'd like to also see links, use this workflow:
+The first documentation workflow is very fast, but it has one limitation: the preview documentation pages will not show any links between pages. If you'd like to also see links, use this workflow:
 
 1. Add roxygen comments to your `.R` files.
 


### PR DESCRIPTION
added 'not', seems to make more sense in context, but I'm not 100% if that's what you mean...

This seems a bit over-the-top for a one-word change, but to honor your instructions to contributors: "I assign the copyright of this contribution to Hadley Wickham"