### PR TITLE
Fixed typos in package structure page

### DIFF
--- a/package.rmd
+++ b/package.rmd
@@ -19,7 +19,7 @@ Before you can create your first package, you need to come up with a name for it
 
 ### Requirements for a name
 
-There are three formal requirement: the name can only consist of letters, numbers and periods, i.e., `.`; it must start with a letter; and it cannot end with a period. Unfortunately, this means you can't use either hyphens or underscores, i.e., `-` or `_`, in your package name. I recommend against using periods in package names because it has confusing connotations (i.e., file extension or S3 method).
+There are three formal requirements: the name can only consist of letters, numbers and periods, i.e., `.`; it must start with a letter; and it cannot end with a period. Unfortunately, this means you can't use either hyphens or underscores, i.e., `-` or `_`, in your package name. I recommend against using periods in package names because it has confusing connotations (i.e., file extension or S3 method).
 
 ### Strategies for creating a name
 
@@ -29,7 +29,7 @@ If you're planning on releasing your package, I think it's worth spending a few 
   find your package (and associated resources) and for you to see who's using it. 
   You can also check if a name is already used on CRAN by loading <http://cran.r-project.org/web/packages/[PACKAGE_NAME]>.
 
-* Avoid using both upper and lower case letters: doing so make the package name
+* Avoid using both upper and lower case letters: doing so makes the package name
   hard to type and even harder to remember. For example, I can never remember if it's
   Rgtk2 or RGTK2 or RGtk2.
 
@@ -117,9 +117,9 @@ To get started with your new package in RStudio, double-click the `pkgname.Rproj
    
 (If you want to learn more RStudio tips and tricks, follow @[rstudiotips](https://twitter.com/rstudiotips) on twitter.)
 
-Both RStudio and `devtools::create()` will make an `.Rproj` file for you. If you have an existing package that doesn't have a `.Rproj` file, you can use `devtools::use_rstudio("path/to/package")` to add it. If you don't use RStudio, you can get many of the benefits by starting a new R session and ensuring the working directory is set to the package directory. 
+Both RStudio and `devtools::create()` will make an `.Rproj` file for you. If you have an existing package that doesn't have an `.Rproj` file, you can use `devtools::use_rstudio("path/to/package")` to add it. If you don't use RStudio, you can get many of the benefits by starting a new R session and ensuring the working directory is set to the package directory. 
 
-### What is a RStudio project file?
+### What is an RStudio project file?
 
 An `.Rproj` file is just a text file. The project file created by devtools looks like this:
 
@@ -164,7 +164,7 @@ A __bundled__ package is a package that's been compressed into a single file. By
 If you decompress a bundle, you'll see it looks almost the same as your source package. The main differences between an uncompressed bundle and a source package are:
 
 * Vignettes are built so that you get HTML and PDF output instead of 
-  Markdown or LaTex input.
+  Markdown or LaTeX input.
 
 * Your source package might contain temporary files used to save time during
   development, like compilation artefacts in `src/`. These are never found in 
@@ -231,7 +231,7 @@ bookdown::embed_png("diagrams/installation.png")
 
 The tool that powers all package installation is the command line tool `R CMD INSTALL` - it can install a source, bundle or a binary package. Devtools functions provide wrappers that allow you to access this tool from R rather than from the command line. `devtools::install()` is effectively a wrapper for `R CMD INSTALL`. `devtools::build()` is a wrapper for `R CMD build` that turns source packages into bundles. `devtools::install_github()` downloads a source package from GitHub, runs `build()` to make vignettes, and then uses `R CMD INSTALL` to do the install. `devtools::install_url()`, `devtools::install_gitorious()`, `devtools::install_bitbucket()` work similarly for packages found elsewhere on the internet.
 
-`install.packages()` and `devtools::install_github()` allow you to install a remote package. Both work by downloading and then installing the package. This makes installation very speedy. `install.packages()` is used to download and install binary package built by CRAN. `install_github()` works a little differently - it downloads a source package, builds it and then installs it.
+`install.packages()` and `devtools::install_github()` allow you to install a remote package. Both work by downloading and then installing the package. This makes installation very speedy. `install.packages()` is used to download and install binary packages built by CRAN. `install_github()` works a little differently - it downloads a source package, builds it and then installs it.
 
 You can prevent files in the package bundle from being included in the installed package using `.Rinstignore`. This works the same way as `.Rbuildignore`, described above. It's rarely needed.
 
@@ -258,7 +258,7 @@ bookdown::embed_png("diagrams/loading.png")
 
 ## What is a library? {#library}
 
-A library is simply a directory containing installed packages. You can have multiple libraries on your computer. In fact, almost every one has at least two: one for packages you’ve installed, and one for the packages that come with every R installation (like base, stats, etc). Normally, the directory with user-installed packages vary based on the version of R that you’re using. That's why it seems like you lose all of your packages when you reinstall R --- they're still on your hard drive, but R can't find them. 
+A library is simply a directory containing installed packages. You can have multiple libraries on your computer. In fact, almost every one has at least two: one for packages you’ve installed, and one for the packages that come with every R installation (like base, stats, etc). Normally, the directories with user-installed packages vary based on the version of R that you’re using. That's why it seems like you lose all of your packages when you reinstall R --- they're still on your hard drive, but R can't find them. 
 
 You can use `.libPaths()` to see which libraries are currently active. Here are mine:
 


### PR DESCRIPTION
Just some more typos I found on the train to work - not sure about the "an vs. a" ones, but changed for consistency.