### PR TITLE
Update how to specify an exact version of R package

### DIFF
--- a/description.rmd
+++ b/description.rmd
@@ -128,7 +128,7 @@ Suggests:
     MASS (>= 7.3.0)
 ```
 
-You almost always want to specify a minimum version rather than an exact version (`MASS (= 7.3.0)`). Since R can't have multiple versions of the same package loaded at the same time, specifying an exact dependency dramatically increases the chance of conflicting versions.
+You almost always want to specify a minimum version rather than an exact version (`MASS (== 7.3.0)`). Since R can't have multiple versions of the same package loaded at the same time, specifying an exact dependency dramatically increases the chance of conflicting versions.
 
 Versioning is most important when you release your package. Usually people don't have exactly the same versions of packages installed that you do. If someone has an older package that doesn't have a function your package needs, they'll get an unhelpful error message. However, if you supply the version number, they'll get a error message that tells them exactly what the problem is: an out of date package. 
 


### PR DESCRIPTION
In DESCRIPTION file, specifying an exact version with a single `=` gives an error. Using `==` worked. I tested this using R 3.1.2.