### PR TITLE
Fix typo in package.rmd

### DIFF
--- a/package.rmd
+++ b/package.rmd
@@ -237,7 +237,7 @@ You can prevent files in the package bundle from being included in the installed
 
 ### In memory packages
 
-To use a package, you must load it into memory. To use it without providing the package name (e.g. `install()` instead of `devtools::install()`), you need to attach it to the search path. R loads packages automatically when you use then. `library()` and `require()` load, then attach an installed package.
+To use a package, you must load it into memory. To use it without providing the package name (e.g. `install()` instead of `devtools::install()`), you need to attach it to the search path. R loads packages automatically when you use them. `library()` and `require()` load, then attach an installed package.
 
 ```{r, eval = FALSE}
 # Automatically loads devtools


### PR DESCRIPTION
Appears to be a typo here.  This may or may not be the intended sentence.

"I assign the copyright of this contribution to Hadley Wickham"