### PR TITLE
Remove one explanation of library vs require

### DIFF
--- a/package.rmd
+++ b/package.rmd
@@ -237,7 +237,7 @@ You can prevent files in the package bundle from being included in the installed
 
 ### In memory packages
 
-To use a package, you must load it into memory. To use it without providing the package name (e.g. `install()` instead of `devtools::install()`), you need to attach it to the search path. R loads packages automatically when you use them. `library()` and `require()` load, then attach an installed package.
+To use a package, you must load it into memory. To use it without providing the package name (e.g. `install()` instead of `devtools::install()`), you need to attach it to the search path. R loads packages automatically when you use them. `library()` (and the later discussed `require()`) load, then attach an installed package.
 
 ```{r, eval = FALSE}
 # Automatically loads devtools
@@ -250,7 +250,7 @@ install()
 
 The distinction between loading and attaching packages is not important when you're writing scripts, but it's very important when you're writing packages. You'll learn more about the difference and why it's important in [search path](#search-path).
 
-The only difference between `library()` and `require()` is what happens if the package isn't installed: `library()` will throw an error, but `require()` returns `FALSE` with a warning. Neither is useful when you're developing a package because you have to install the package first. In future chapters you'll learn about `devtools::load_all()` and RStudio's "Build and reload", which allows you to skip install and load a source package directly into memory:
+`library()` is not useful when you're developing a package because you have to install the package first. In future chapters you'll learn about `devtools::load_all()` and RStudio's "Build and reload", which allows you to skip install and load a source package directly into memory:
 
 ```{r, echo = FALSE}
 bookdown::embed_png("diagrams/loading.png")
@@ -285,12 +285,14 @@ lapply(.libPaths(), dir)
 
 The first lib path is for the packages I've installed (I've installed at lot!). The second is for so-called "recommended" packages that come with every installation of R.
 
-When you use `library(pkg)` to load a package, R looks through each path in `.libPaths()` to see if a directory called `pkg` exists. If it doesn't exist, you'll get an error message:
+When you use `library(pkg)` or `require(pkg)` to load a package, R looks through each path in `.libPaths()` to see if a directory called `pkg` exists. If it doesn't exist, you'll get an error message:
 
 ```{r, error = TRUE}
 library(blah)
+# or:
+require(blah)
 ```
 
-The main difference between `library()` and `require()` is what happens when a package isn't found. While `library()` throws an error, `require()` prints a message and returns FALSE. In practice this distinction isn't important because when building a package you should __NEVER__ use either inside a package. See [package dependencies](#dependencies) for what you should do instead.
+The main difference between `library()` and `require()` is what happens if a package isn't found. While `library()` throws an error, `require()` prints a warning message and returns FALSE. In practice this distinction isn't important because when building a package you should __NEVER__ use either inside a package. See [package dependencies](#dependencies) for what you should do instead.
 
 When you start learning R, it's easy to get confused between libraries and packages because you use `library()` function to load a _package_. However, the distinction between the two is important and useful. For example, one important application is packrat, which automates the process of managing project specific libraries. With packrat, when you upgrade a package in one project, it only affects that project, not every project on your computer. This is useful because it allows you to play around with cutting-edge packages without affecting other projects' use of older, more reliable packages. This is also useful when you're both developing and using a package.


### PR DESCRIPTION
Manuscript contained two almost identical explanations about the difference between library() and require(). Removed the first explanation (in the "In memory packages" section) but included a forward reference, kept the explanation in the What is a library? section.

I assign the copyright of this contribution to Hadley Wickham.