### PR TITLE
Update package.rmd to remove duplication.

### DIFF
--- a/package.rmd
+++ b/package.rmd
@@ -250,7 +250,10 @@ install()
 
 The distinction between loading and attaching packages is not important when you're writing scripts, but it's very important when you're writing packages. You'll learn more about the difference and why it's important in [search path](#search-path).
 
-The only difference between `library()` and `require()` is what happens if the package isn't installed: `library()` will throw an error, but `require()` returns `FALSE` with a warning. Neither is useful when you're developing a package because you have to install the package first. In future chapters you'll learn about `devtools::load_all()` and RStudio's "Build and reload", which allows you to skip install and load a source package directly into memory:
+The only difference between `library()` and `require()` is what happens if the package isn't installed: `library()` will throw an error, but `require()` returns `FALSE` with a warning.
+In practice this distinction isn't important because when building a package you should __NEVER__ use either inside a package.
+See [package dependencies](#dependencies) for what you should do instead.
+In future chapters you'll learn about `devtools::load_all()` and RStudio's "Build and reload", which allows you to skip install and load a source package directly into memory:
 
 ```{r, echo = FALSE}
 bookdown::embed_png("diagrams/loading.png")
@@ -290,7 +293,5 @@ When you use `library(pkg)` to load a package, R looks through each path in `.li
 ```{r, error = TRUE}
 library(blah)
 ```
-
-The main difference between `library()` and `require()` is what happens when a package isn't found. While `library()` throws an error, `require()` prints a message and returns FALSE. In practice this distinction isn't important because when building a package you should __NEVER__ use either inside a package. See [package dependencies](#dependencies) for what you should do instead.
 
 When you start learning R, it's easy to get confused between libraries and packages because you use `library()` function to load a _package_. However, the distinction between the two is important and useful. For example, one important application is packrat, which automates the process of managing project specific libraries. With packrat, when you upgrade a package in one project, it only affects that project, not every project on your computer. This is useful because it allows you to play around with cutting-edge packages without affecting other projects' use of older, more reliable packages. This is also useful when you're both developing and using a package.


### PR DESCRIPTION
Discussion of difference between `library()` and `require()` was largely duplicated.