### PR TITLE
backslash changed to fowardslash

### DIFF
--- a/src.rmd
+++ b/src.rmd
@@ -130,7 +130,7 @@ The distinctions between the two export directives is important:
 
 * `[[Rcpp::export]]` makes the C++ function available to R. If you have
   trouble remembering the exact details, note that everything comes in 
-  twos: Two `\`, two `[`, two `:` and two `]`.
+  twos: Two `/`, two `[`, two `:` and two `]`.
 
 * `@export` makes the R wrapper function available outside your package by
   adding it to the `NAMESPACE`.


### PR DESCRIPTION
In the "everything comes in twos" example the slash was going the wrong way.