### PR TITLE
Travis now supports R as a top-level language

### DIFF
--- a/check.rmd
+++ b/check.rmd
@@ -662,78 +662,29 @@ With this setup in place, every time you push to GitHub, and every time someone 
 
 ### Basic config
 
-The Travis config is stored in a yaml file called `.travis.yml`. The default config created by devtools looks like this:
+Travis now supports R as a top-level language. Existing users should check out the [porting quide](https://github.com/craigcitro/r-travis/wiki/Porting-to-native-R-support-in-Travis) written by [Craig Citro](https://github.com/craigcitro/r-travis). The Travis config is stored in a yaml file called `.travis.yml`.  The default config created by devtools looks like this:
 
 ```yaml
-# Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
-language: c
+# Sample .travis.yml for R projects
 
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
+language: r
+warnings_are_errors: true
 
-install:
-  - ./travis-tool.sh install_deps
-
-script: 
-  - ./travis-tool.sh run_tests
-
-after_failure:
-  - ./travis-tool.sh dump_logs
+notifications:
+  email:
+    on_success: change
+    on_failure: change
 ```
 
-Travis doesn't currently support R as a top-level language, so we need to install it. We start with an image designed for testing C projects, then download the `travis-tool` script written by [Craig Citro](https://github.com/craigcitro/r-travis). It starts downloads from GitHub that provides a number of useful tools:
+`warnings_are_errors: true` will make the build fail if there are any `ERROR`s or any `WARNING`s. The default is to fail only on errors. I recommend using this if you plan to submit to CRAN. You will be notified by email when the build status changes.
 
-* `./travis-tool.sh bootstrap`: installs R.
-
-* `./travis-tool.sh install_deps`: installs all packages needed to run tests.
-
-* `./travis-tool.sh run_tests`: builds the package and checks it
-
-* `./travis-tool.sh dump_logs`: on failure, print out all relevant logs so
-  you can easily read online.
-
-There are two ways to install packages not included in the basic script:
-
-* `./travis-tool.sh install_github user/repo`: installs a package from
-  GitHub. 
-
-* `./travis-tool.sh r_binary_install package`: installs a precompiled R 
-  package from ubuntu. You can see if a binary version of a package is 
-  available by searching on <http://packages.ubuntu.com> for 
-  `r-cran-lowercasename`. For example, searching for `r-cran-xml` reveals that 
-  you can get a binary version of the XML package.
-  
-These commands should be included in the `install` block, before `./travis-tool.sh install_deps`:
+To install packages from github during testing use:
 
 ```yaml
-install:
-  - ./travis-tool.sh r_binary_install XML`
-  - ./travis-tool.sh install_github hadley/pryr
-  - ./travis-tool.sh install_deps
+r_github_packages:
+ - hadley/httr
 ```
 
-You can set environment variables using the `env` field. Here are three useful flags:
-
-```yaml
-env:
-  - BOOTSTRAP_LATEX=1
-  - _R_CHECK_FORCE_SUGGESTS_=0
-  - WARNINGS_ARE_ERRORS=1
-```
-
-* `BOOTSTRAP_LATEX=1`: also install latex. This is useful if you want to 
-  check the pdf manual or pdf vignettes. It's not the default because it adds 
-  substantially to the check time.
-
-* `WARNINGS_ARE_ERRORS=1`: make the build fail if there are any `ERROR`s or 
-  any `WARNING`s. The default is to fail only on errors. I recommend using
-  this if you plan to submit to CRAN.
-
-* `_R_CHECK_FORCE_SUGGESTS_=0`: run check even if all suggested packages can't 
-  be installed.
-  
 ### Other uses
 
 Since Travis allows you to run arbitrary code, there are many other things that you can use it for:


### PR DESCRIPTION
I used the website for R-packages to submit my first package to CRAN. Thanks for a great resource!! I noticed that this section was out of date. My suggestions are in the proposed change. 

From the official documentation: "The R environment comes with LaTeX and pandoc preinstalled, making it easier to use packages like RMarkdown or knitr." This suggests BOOTSTRAP_LATEX=1 is no longer needed.

I didn't see any mention of "`_R_CHECK_FORCE_SUGGESTS_=0`" so I am not sure if it is still available as an option.
