### PR TITLE
When using system.file, use mustWork = TRUE to have an error message

### DIFF
--- a/data.rmd
+++ b/data.rmd
@@ -114,12 +114,17 @@ If you want to show examples of loading/parsing raw data, put the original files
 system.file("extdata", "2012.csv", package = "testdat")
 ```
 
-Beware: if the file does not exist, `system.file()` does not return an error - it just returns the empty string:
+Beware: by default, if the file does not exist, `system.file()` does not return an error - it just returns the empty string:
 
 ```{r}
 system.file("extdata", "2010.csv", package = "testdat")
 ```
 
+If you want to have an error message when the file does not exist, add the argument `mustWork = TRUE`:
+
+```{r, error = TRUE}
+system.file("extdata", "2010.csv", package = "testdat", mustWork = TRUE)
+```
 ## Other data {#other-data}
 
 * Data for tests: it's ok to put small files directly in your test directory.


### PR DESCRIPTION
When one call internal data from the _extdata_ folder, it should be useful to have an error message when the data requested does not exist. This way, there is no need to write an error control instruction as `if (sysfile_result == "") stop("File does not exist")`

Thank you for this amazing book!

If this commit should be useful, I assign the copyright of this contribution to Hadley Wickham
