### PR TITLE
added OS X to case-insensitive operating systems

### DIFF
--- a/r.rmd
+++ b/r.rmd
@@ -38,7 +38,7 @@ foo.r
 stuff.r
 ```
 
-Pay attention to capitalization, since you, or some of your collaborators, might be using an operating system with a case-insensitive file system (e.g., Microsoft Windows). Avoid problems by never using filenames that differ only in capitalisation.
+Pay attention to capitalization, since you, or some of your collaborators, might be using an operating system with a case-insensitive file system (e.g., Microsoft Windows or OS X). Avoid problems by never using filenames that differ only in capitalisation.
 
 My rule of thumb is that if I can't remember the name of the file where a function lives, I need to either separate the functions into more files or give the file a better name. (Unfortunately you can't use subdirectories inside `R/`. The next best thing is to use a common prefix, e.g., `abc-*.R`.).
 

--- a/style.rmd
+++ b/style.rmd
@@ -32,7 +32,7 @@ If files need to be run in sequence, prefix them with numbers:
     1_parse.R
     2_explore.R
 
-Pay attention to capitalization, since you, or some of your collaborators, might be using an operating system with a case-insensitive file system (e.g., Microsoft Windows) which can lead to problems with (case-sensitive) revision control systems. Never use filenames that differ only in capitalisation.
+Pay attention to capitalization, since you, or some of your collaborators, might be using an operating system with a case-insensitive file system (e.g., Microsoft Windows or OS X) which can lead to problems with (case-sensitive) revision control systems. Never use filenames that differ only in capitalisation.
 
 ### Object names
 


### PR DESCRIPTION
I assign the copyright of this contribution to Hadley Wickham.

@hadley, just adding "OS X" inside the parenthetical comment regarding case-insensitive file systems. I had that bite us while working on Stan recently. On a default configuration of the file system on a Mac, you can verify this with:
```
> touch foo
> touch Foo
> ls *oo
foo
```

(there won't be two separate files, as you'd expect on a case-sensitive file system; odd thing is that bash is case sensitive even though the file system is not)