### PR TITLE
packageVersion("foo") > "1.0.0"

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -139,7 +139,7 @@ There are good reasons to make backward incompatible changes - if you made a des
     notes. For example:
     
     ```{r, eval = FALSE}
-    if (packageVersion("foo" > "1.0.0")) {
+    if (packageVersion("foo") > "1.0.0") {
       foo::baz()
     } else {
       foo::bar()


### PR DESCRIPTION
instead of packageVersion("foo" > "1.0.0")

@hadley, do you prefer suggestions to be made here, or in http://www.oreilly.com/catalog/errataunconfirmed.csp?isbn=0636920034421