### PR TITLE
accidentally being added

### DIFF
--- a/git.rmd
+++ b/git.rmd
@@ -298,7 +298,7 @@ Remember that these directives are aspirational. You shouldn't let them get in y
 
 ## Ignoring files {#git-ignore}
 
-Often, there are files that you don't want to include in the repository. They might be transient (like LaTex or C build artefacts), very large, or generated on demand. Rather than carefully _not_ staging them each time, you should instead add them to `.gitignore`. This will prevent them from ever being added. The easiest way to do this is to right-click on the file in the Git pane and select `Ignore`:
+Often, there are files that you don't want to include in the repository. They might be transient (like LaTex or C build artefacts), very large, or generated on demand. Rather than carefully _not_ staging them each time, you should instead add them to `.gitignore`. This will prevent them from accidentally being added. The easiest way to do this is to right-click on the file in the Git pane and select `Ignore`:
 
 ```{r, echo = FALSE}
 bookdown::embed_png("screenshots/git-ignore.png", dpi = 220)


### PR DESCRIPTION
Does *accidentally* fit better than *ever* in  "This will prevent them from accidentally being added."?  I believe you can still add files through the git command line, even if they're already in the .gitignore file.

("I assign the copyright of this contribution to Hadley Wickham".)