### PR TITLE
non-ASCII & encoding in Rdata files

### DIFF
--- a/check.rmd
+++ b/check.rmd
@@ -433,7 +433,7 @@ tools:::.check_package_compact_sysdata
     * The data directory can only contain file types described in 
       [exported data](#data-data).
       
-    * Data files can only contain non-ASCII characters if the encoding is 
+    * Data files can contain non-ASCII characters only if the encoding is 
       not correctly set. This usually shouldn't be a problem if you're saving
       `.Rdata` files. If you do see this error, look at the `Encoding()` of
       each column in the data frame, and ensure none are "unknown". (You'll 


### PR DESCRIPTION
Should it be
> Data files can contain non-ASCII characters *only* if the encoding is not correctly set.

instead of
> Data files can *only* contain non-ASCII characters if the encoding is not correctly set. 

?  Fortunately I've never had to deal with this.

(I assign the copyright of this contribution to Hadley Wickham.)