### PR TITLE
slightly modified in the "Binary builds" section.

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -477,7 +477,7 @@ Unless you feel extremely strongly that discussion is merited, don't respond to 
 
 ### Binary builds
 
-After the package has been accepted by CRAN it will be built for each platform. It's possible this may uncover further errors. Wait 48 hours until all the checks for all packages have been run, then go to the check results package for your package:
+After the package has been accepted by CRAN it will be built for each platform. It's possible this may uncover further errors. Wait 48 hours until all the checks for all packages have been run, then go to the check results page for your package:
 
 ```{r, echo = FALSE}
 bookdown::embed_png("screenshots/cran-checks.png", dpi = 220)


### PR DESCRIPTION
Changed from

```
Wait 48 hours until all the checks for all packages have been run, then go to the check results package for your package:
```

to

```
Wait 48 hours until all the checks for all packages have been run, then go to the check results page for your package:
```
