### PR TITLE
`.rda` extension is case sensitive

### DIFF
--- a/data.rmd
+++ b/data.rmd
@@ -32,7 +32,7 @@ x <- sample(1000)
 devtools::use_data(x, mtcars)
 ```
 
-It's possible to use other types of files, but I don't recommend it because `.RData` files are already fast, small and explicit. Other options are described in `data()`. For larger datasets, you may want to experiment with the compression setting. The default is `bzip2`, but sometimes `gzip` or `xz` can create smaller files (typically at the expense of slower loading times).
+It's possible to use other types of files, but I don't recommend it because `.RData` files are already fast, small and explicit. Other options are described in `data()`. For larger datasets, you may want to experiment with the compression setting. The default is `bzip2`, but sometimes `gzip` or `xz` can create smaller files (typically at the expense of slower loading times).  Sometimes the extension `.rda` is used for `.RData` files.  These extensions are interchangeable; you can `save()` data files using either extension.  Although you will sometimes see `.Rda` and `.rda` used interchangeably in R tutorials, CRAN check will only see data files that use the lowercase extension `.rda`.
 
 If the `DESCRIPTION` contains `LazyData: true`, then datasets will be lazily loaded. This means that they won't occupy any memory until you use them. The following example shows memory usage before and after loading the nycflights13 package. You can see that memory usage doesn't change until you inspect the flights dataset stored inside the package. 
 


### PR DESCRIPTION
Per [SO](https://stackoverflow.com/questions/21370132/r-data-formats-rdata-rda-rds-etc) and the [RHelp](http://r.789695.n4.nabble.com/rda-vs-RData-td4581445.html) list, `.RData` is the same as `.rda`.

CRAN (and `data()`) won't see files with `.Rda` extensions.  This is unfortunate, because `.Rda` appears frequently in the wild in tutorials.
