### PR TITLE
Readability of expect_match example

### DIFF
--- a/tests.rmd
+++ b/tests.rmd
@@ -182,10 +182,9 @@ While you'll normally put expectations inside tests inside files, you can also r
     string <- "Testing is fun!"
 
     expect_match(string, "Testing") 
-    # Fails, match is case-sensitive
-    expect_match(string, "testing")
 
-    # Additional arguments are passed to grepl:
+# Match is case-sensitive
+    expect_match(string, "testing")
     expect_match(string, "testing", ignore.case = TRUE)
     ```
 


### PR DESCRIPTION
I was initially confused about whether the error message was in the right place. I think this will be more clear.

I assign the copyright of this contribution to Hadley Wickham