### PR TITLE
Update release.rmd

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -312,7 +312,7 @@ I recommend following the [CRAN Policy Watch](https://twitter.com/CRANPolicyWatc
 
 ## Important files {#important-files}
 
-You now have a package that's ready to submit to CRAN. But before you do, there are two important files that you should update: `README.md` which describes what the package does, and `NEWS.md` which describes what's changed since the previous version. I recommend using Markdown for these files, because it's useful for them to be readable as both plain text (e.g. in emails) and HTML (e.g. on GitHub, in blog posts). I recommend using Github flavoured Markdown, <https://help.github.com/articles/GitHub-flavored-Markdown/>, for these files.
+You now have a package that's ready to submit to CRAN. But before you do, there are two important files that you should update: `README.md` which describes what the package does, and `NEWS.md` which describes what's changed since the previous version. I recommend using Markdown for these files, because it's useful for them to be readable as both plain text (e.g. in emails) and HTML (e.g. on GitHub, in blog posts). I recommend using Github flavoured Markdown, <https://help.github.com/articles/github-flavored-markdown/>, for these files.
 
 ### README.md {#readme}
 


### PR DESCRIPTION
Correct URL. The original linked page is dead. There is a page with similar url but lowercase, which I've suggested in my change. It redirects to https://help.github.com/articles/working-with-advanced-formatting/. Alternatively, there's https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown.
