### PR TITLE
Added text about Rtools paths

### DIFF
--- a/intro.rmd
+++ b/intro.rmd
@@ -133,7 +133,7 @@ devtools::install_github("hadley/devtools")
 You'll also need a C compiler and a few other command line tools. If you're on Windows or Mac and you don't already have them, RStudio will install them for you. Otherwise:
 
 * On Windows, download and install [Rtools](http://cran.r-project.org/bin/windows/Rtools/). 
-  NB: this is not an R package!
+  NB: this is not an R package!  Be sure the system path includes the appropriate Rtools directories. As of this writing, this can be accomplished by checking a box that allows the path to be updated during the installation of Rtools.  If your Rtools folders are not included in the system path correctly, error 127 is thrown by "has_devel()" (see below)
 
 * On Mac, make sure you have either XCode (available for free in the App Store)
   or the ["Command Line Tools for Xcode"](http://developer.apple.com/downloads).


### PR DESCRIPTION
I was receiving error 127 when I ran has_devel().  After a lot of sleuthing, I found that the default setting when installing Rtools did not update the system path.  I have added language to the instructions for Rtools installation that warns the user to check the box to allow the installation package to update the system path.

“I assign the copyright of this contribution to Hadley Wickham
