### PR TITLE
Emphasis on data file name being same as object name.

### DIFF
--- a/data.rmd
+++ b/data.rmd
@@ -25,7 +25,7 @@ Each possible location is described in more detail below.
 
 ## Exported data {#data-data}
 
-The most common location for package data is (surprise!) `data/`. Each file in this directory should be a `.RData` file created by `save()` containing a single object (with the same name as the file). The easiest way to adhere to these rules is to use `devtools::use_data()`:
+The most common location for package data is (surprise!) `data/`. Each file in this directory should be a `.RData` file created by `save()` containing a single object (**with the same name as the file**). The easiest way to adhere to these rules is to use `devtools::use_data()`:
 
 ```{r, eval = FALSE}
 x <- sample(1000)


### PR DESCRIPTION
I assign the copyright of this contribution to Hadley Wickham

I was unable to build and check my package because the data file name was different than the object name. Maybe I'm the only person who has run into this issue, but the "same name" caveat is very important and (IMO) worth emphasis.
