### PR TITLE
Explain how to share unit tests with a source package

### DIFF
--- a/tests.rmd
+++ b/tests.rmd
@@ -396,6 +396,8 @@ test_that("floor_date works for different units", {
 
 The highest-level structure of tests is the file. Each file should contain a single `context()` call that provides a brief description of its contents. Just like the files in the `R/` directory, you are free to organise your tests any way that you like. But again, the two extremes are clearly bad (all tests in one file, one file per test). You need to find a happy medium that works for you. A good starting place is to have one file of tests for each complicated function.
 
+By default, `devtools::use_testthat()` locates you tests in the `tests/` directory. People you cooperate with will not be able to run `testthat::test_package("packagename")` because `tests/` is not exported with the source package. This is fine for most cases, except when you do want to share tests. Move the `tests/` directory to `inst/tests/` to export tests with the source package and enable your correspondents to run `testthat::test_package("packagename")`.
+
 ## CRAN notes {#test-cran}
 
 CRAN will run your tests on all CRAN platforms: Windows, Mac, Linux and Solaris. There are a few things to bear in mind:


### PR DESCRIPTION
Explain that moving tests to `inst/tests` enables `testthat::test_package()` to work.

Related [stackoverflow discussion](http://stackoverflow.com/questions/36575050/how-to-test-an-installed-package-with-testthat/36575128#36575128).