### PR TITLE
Fixed a typo in LaTeX name

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -416,6 +416,6 @@ You'll need to watch the file size. If you include a lot of graphics, it's easy 
 
 ## Where next {#where-next}
 
-If you'd like more control over the appearance of your vignette, you'll need to learn more about Rmarkdown. The website, <http://rmarkdown.rstudio.com>, is a great place to start. There you can learn about alternative output formats (like LaTeX and pdf) and how you can incorporate raw HTML and LateX if you need additional control.
+If you'd like more control over the appearance of your vignette, you'll need to learn more about Rmarkdown. The website, <http://rmarkdown.rstudio.com>, is a great place to start. There you can learn about alternative output formats (like LaTeX and pdf) and how you can incorporate raw HTML and LaTeX if you need additional control.
 
 If you write a nice vignette, consider submitting it to the _Journal of Statistical Software_ or _The R Journal_. Both journals are electronic only and peer-reviewed. Comments from reviewers can be very helpful for improving the quality of your vignette and the related software.


### PR DESCRIPTION
Hi Hadley,

it is just a spotted character case change, not much to be copyrighted :)

But: "I assign the copyright of this contribution to Hadley Wickham"

Andrej