### PR TITLE
Google's R style guide link update

### DIFF
--- a/r.rmd
+++ b/r.rmd
@@ -56,7 +56,7 @@ After navigating to a function using one of these tools, you can go back to wher
 
 ## Code style {#style}
 
-Good coding style is like using correct punctuation. You can manage without it, but it sure makes things easier to read. As with styles of punctuation, there are many possible variations. The following guide describes the style that I use (in this book and elsewhere). It is based on Google's [R style guide](https://google-styleguide.googlecode.com/svn/trunk/Rguide.xml), with a few tweaks. 
+Good coding style is like using correct punctuation. You can manage without it, but it sure makes things easier to read. As with styles of punctuation, there are many possible variations. The following guide describes the style that I use (in this book and elsewhere). It is based on Google's [R style guide](https://google.github.io/styleguide/Rguide.xml), with a few tweaks. 
 
 You don't have to use my style, but I strongly recommend that you use a consistent style and you document it. If you're working on someone else's code, don't impose your own style. Instead, read their style documentation and follow it as closely as possible.
 


### PR DESCRIPTION
The link to Google's R style guide is not working anymore. I replaced it with the page in google's github: https://google.github.io/styleguide/Rguide.xml
