### PR TITLE
fixes link to R-exts DESCRIPTION file section

### DIFF
--- a/description.rmd
+++ b/description.rmd
@@ -387,4 +387,4 @@ A number of other fields are described elsewhere in the book:
 
 There are actually many other rarely, if ever, used fields. A complete list can be found in the "The DESCRIPTION file" section of the [R extensions manual][R-exts]. You can also create your own fields to add additional metadata. The only restrictions are that you shouldn't use existing names and that, if you plan to submit to CRAN, the names you use should be valid English words (so a spell-checking NOTE won't be generated).
 
-[R-exts]: http://cran.r-project.org/doc/manuals/R-exts.html#Licensing
+[R-exts]: http://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file


### PR DESCRIPTION
The link to the DESCRIPTION file section of the R extensions manual currently points to the section on Licensing, rather than (the previous section) summarizing the DESCRIPTION file
