### PR TITLE
Edit explanations of package loading and attaching

### DIFF
--- a/package.rmd
+++ b/package.rmd
@@ -237,7 +237,15 @@ You can prevent files in the package bundle from being included in the installed
 
 ### In memory packages
 
-To use a package, you must load it into memory. To use it without providing the package name (e.g. `install()` instead of `devtools::install()`), you need to attach it to the search path. R loads packages automatically when you use them. `library()` (and the later discussed `require()`) load, then attach an installed package.
+There are several stages involved before using a package:
+1.Package installed. 
+	With `install.packages` or `devtools::install()` etc, package is downloaded and installed, but not available to use yet.
+2.Package loaded into memory. 
+	Package can be used with prefix like `ggplot2::ggplot()`. You can explicitly load a package without attaching it with `requireNamespace()` or `loadNamespace()` but rarely need it. If you run `ggplot2::ggplot` without loading `ggplot2` package first, it will be loaded automatically. Although you still need the prefix in every usage.
+3.Package attached to search path.
+	Package can be used without prefix. Same name in newly attached package will mask older name. `library()` and `require()` actually go through stage 2 and 3 in one step. 
+	
+	The search path is about namespaces context, while similar to set path in windows/linux software installation in concept, it has nothing to do with package installation. 
 
 ```{r, eval = FALSE}
 # Automatically loads devtools


### PR DESCRIPTION
I was confused in reading the section `In memory packages` in chapter `Package structure`. I read the Namespaces chapter in`Advanced R` several times, then came back to read this part again. Now I found all the descriptions are accurate, but there are many names bear meanings different from what a reader may assume. I tried to edit it from the viewpoint of reader, just for your reference.

The points I tried to make are:
- Define the 3 stages `installation, loading, attaching` in very beginning. Without more detailed understanding of `loaded into memory` and `search path`, user could assume their meaning from his/her previous experience. For example he/she may think `loaded into memory` means immediately available to use, or `added to search path` happened in package installation but package is not in memory yet.
- Change the example of `devtools::install()` because any package will fit this example, while this one may add yet another similar names as cognition burden.
