### PR TITLE
subtitle `The NAMESPACE` not working in content

### DIFF
--- a/namespace.rmd
+++ b/namespace.rmd
@@ -105,7 +105,7 @@ Unless there is a good reason otherwise, you should always list packages in `Imp
 
 Now that you understand the importance of the namespace, let's dive into the nitty gritty details. The two sides of the package namespace, imports and exports, are both described by the `NAMESPACE`. You'll learn what this file looks like in the next section. In the section after that, you'll learn the details of exporting and importing functions and other objects.
 
-## The `NAMESPACE` {#NAMESPACE}
+## The `NAMESPACE` {#the NAMESPACE}
 
 The following code is an excerpt of the `NAMESPACE` file from the testthat package.
 


### PR DESCRIPTION
The side bar content subtitle `The NAMESPACE` is undefined. I'm not sure how it can be solved, but noticed that the {#NAMESPACE} duplicate with the first subtitle #namespace.
