### PR TITLE
`data.table` exception

### DIFF
--- a/namespace.rmd
+++ b/namespace.rmd
@@ -276,6 +276,8 @@ It's confusing that both `DESCRIPTION` (through the `Imports` field) and
 
 It's common for packages to be listed in `Imports` in `DESCRIPTION`, but not in `NAMESPACE`. In fact, this is what I recommend: list the package in `DESCRIPTION` so that it's installed, then always refer to it explicitly with `pkg::fun()`. Unless there is a strong reason not to, it's better to be explicit. It's a little more work to write, but a lot easier to read when you come back to the code in the future. The converse is not true. Every package mentioned in `NAMESPACE` must also be present in the `Imports` or `Depends` fields.
 
+One exception is you may have to add `import(data.table)` in `NAMESPACE` if you want to use `data.table` in your package. Otherwise the `data.table` special syntax inside `[]` may cause problem if it is not imported. See details [here](http://stackoverflow.com/questions/10527072/using-data-table-package-inside-my-own-package).
+
 ### R functions {#import-r}
 
 If you are using just a few functions from another package, my recommendation is to note the package name in the `Imports:` field of the `DESCRIPTION` file and call the function(s) explicitly using `::`, e.g., `pkg::fun()`.


### PR DESCRIPTION
I totally agree with the recommendation of explicitly refer other package functions, but `data.table`'s special syntax inside [] may have problem if it is not imported. My edit probably didn't really explain the problem well. I just found the problem hard way, so I felt it worth to be mentioned.

I also have another problem with this general recommendation. I used lots of `stringr` methods, and using them explicitly make some very long statements, which is ugly in deep indented structure, because I have to wrap and indent a lot. I think in this case since most `stringr` method have a distinct prefix, it's very easy to notice these method came from `stringr`, thus importing `stringr` and avoiding the `stringr::` actually helps on code readability a lot.
