### PR TITLE
`Imports` assume installing CRAN version

### DIFF
--- a/description.rmd
+++ b/description.rmd
@@ -74,6 +74,8 @@ Both `Imports` and `Suggests` take a comma separated list of package names. I re
     millions of times). You'll learn about alternative ways to call functions
     in other packages in [namespace imports](#imports).
 
+    One caveat is that if your code depend on some packages' more recent github version, `Imports` only make sure the CRAN version is installed when other user install your package. You may have to notify user to install latest version manually first.
+
 *   `Suggests`: your package can use these packages, but doesn't require them.
     You might use suggested packages for example datasets, to run tests, 
     build vignettes, or maybe there's only one function that needs the package.


### PR DESCRIPTION
I found this in a really hard way. 

I tested my package a lot, put it to github, tried to install it to my laptop, then there were lots of errors. At first the error seemed to be `data.table` awareness problem, but further debugging point to a Shiny DT rowselected value to be character in laptop. Turned out I installed the newest github version `DT` in my PC since this is recommended by `DT` website, but my laptop only installed the CRAN version of `DT` because the Imports field only assume this.
