### PR TITLE
fix invalid url on github-flavored-markdown

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -312,7 +312,7 @@ I recommend following the [CRAN Policy Watch](https://twitter.com/CRANPolicyWatc
 
 ## Important files {#important-files}
 
-You now have a package that's ready to submit to CRAN. But before you do, there are two important files that you should update: `README.md` which describes what the package does, and `NEWS.md` which describes what's changed since the previous version. I recommend using Markdown for these files, because it's useful for them to be readable as both plain text (e.g. in emails) and HTML (e.g. on GitHub, in blog posts). I recommend using Github flavoured Markdown, <https://help.github.com/articles/GitHub-flavored-Markdown/>, for these files.
+You now have a package that's ready to submit to CRAN. But before you do, there are two important files that you should update: `README.md` which describes what the package does, and `NEWS.md` which describes what's changed since the previous version. I recommend using Markdown for these files, because it's useful for them to be readable as both plain text (e.g. in emails) and HTML (e.g. on GitHub, in blog posts). The basic writing and formatting syntax is available at <https://help.github.com/articles/basic-writing-and-formatting-syntax/>.
 
 ### README.md {#readme}
 


### PR DESCRIPTION
Just happen to find a invalid url on github-flavored-markdown.  A possible replacement url is suggested.  (Thx for this great repo on R pkg.)
