### PR TITLE
Specify *pkgbuild::*has_devel()

### DIFF
--- a/intro.rmd
+++ b/intro.rmd
@@ -147,7 +147,7 @@ You can check that you have everything installed and working by running the foll
 
 ```{r, eval = FALSE}
 library(devtools)
-has_devel()
+pkgbuild::has_devel()
 #> '/Library/Frameworks/R.framework/Resources/bin/R' --vanilla CMD SHLIB foo.c 
 #> 
 #> clang -I/Library/Frameworks/R.framework/Resources/include -DNDEBUG 


### PR DESCRIPTION
Running code as in book (i.e., without this specification) caused error messages on my system:
====
> library(devtools)
> has_devel()
Error: could not find function "has_devel"
> devtools::has_devel()
Error: 'has_devel' is not an exported object from 'namespace:devtools'
> ??has_devel
> pkgbuild::has_devel()
[1] TRUE
====