### PR TITLE
Fixed weird ub character appearing in some code chunks

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -234,7 +234,7 @@ Knitr allows you to intermingle code, results and text. Knitr takes R code, runs
 
 Consider the simple example below. Note that a knitr block looks similar to a fenced code block, but instead of using `r`, you using `{r}`.
 
-    ```{r}
+    ```{r}
     # Add two numbers together
     add <- function(a, b) a + b
     add(10, 20)
@@ -266,13 +266,13 @@ You can specify additional options to control the rendering:
 
 * To affect a single block, add the block settings:
 
-        ```{r, opt1 = val1, opt2 = val2}
+        ```{r, opt1 = val1, opt2 = val2}
         # code
         ```
   
 * To affect all blocks, call `knitr::opts_chunk$set()` in a knitr block:
     
-        ```{r, echo = FALSE}
+        ```{r, echo = FALSE}
         knitr::opts_chunk$set(
           opt1 = val1,
           opt2 = val2
@@ -309,7 +309,7 @@ The most important options are:
   code output. I usually set these globally by putting the following knitr
   block at the start of my document.
 
-        ```{r, echo = FALSE}
+        ```{r, echo = FALSE}
         knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
         ```
 
@@ -317,7 +317,7 @@ The most important options are:
     This is useful if you want to generate text from your R code. For example,
     if you want to generate a table using the pander package, you'd do:
   
-        ```{r, results = "asis"}
+        ```{r, results = "asis"}
         pander::pandoc.table(iris[1:3, 1:4])
         ```
     


### PR DESCRIPTION
In some places in the knitr section a strange \ub character had appeared. This fix removes them.