### PR TITLE
remove extra single quotes: .onLoad, devtools.desc.author

### DIFF
--- a/r.rmd
+++ b/r.rmd
@@ -381,7 +381,7 @@ Some common uses of `.onLoad()` and `.onAttach()` are:
         devtools.path = "~/R-dev",
         devtools.install.args = "",
         devtools.name = "Your name goes here",
-        devtools.desc.author = '"First Last <first.last@example.com> [aut, cre]"',
+        devtools.desc.author = "First Last <first.last@example.com> [aut, cre]",
         devtools.desc.license = "What license is it under?",
         devtools.desc.suggests = NULL,
         devtools.desc = list()


### PR DESCRIPTION
Original code created extra quotes:
> getOption("devtools.desc.author")
[1] "\"First Last <first.last@example.com> [aut, cre]\""