### PR TITLE
add information on how to create roxygen2 skeletons with `sinew`

### DIFF
--- a/man.rmd
+++ b/man.rmd
@@ -94,17 +94,20 @@ oldbookdown::screenshot("screenshots/man-add.png", dpi = 220)
 
 The first documentation workflow is very fast, but it has one limitation: the preview documentation pages will not show any links between pages. If you'd like to also see links, use this workflow:
 
-1. Add roxygen comments to your `.R` files.
+1. Add roxygen comments to your `.R` files. 
 
-1. Click `r oldbookdown::screenshot("screenshots/build-reload.png", dpi = 220)`
+  - To facilitate this you can use the [sinew](https://github.com/metrumresearchgroup/sinew) package to create a skeleton of the relevant populated fields with information scraped
+  from the within the function script.
+
+2. Click `r oldbookdown::screenshot("screenshots/build-reload.png", dpi = 220)`
    in the build pane or press Ctrl/Cmd + Shift + B. This completely rebuilds the 
    package, including updating all the documentation, installs it in your
    regular library, then restarts R and reloads your package. This is 
    slow but thorough.
 
-1. Preview documentation with `?`.
+3. Preview documentation with `?`.
 
-1. Rinse and repeat until the documentation looks the way you want.
+4. Rinse and repeat until the documentation looks the way you want.
 
 If this workflow doesn't seem to be working, check your project options in RStudio. Old versions of devtools and RStudio did not automatically update the documentation when the package was rebuilt:
 

--- a/man.rmd
+++ b/man.rmd
@@ -135,7 +135,7 @@ sinew::makeOxygen(lm)
 
 The first documentation workflow is very fast, but it has one limitation: the preview documentation pages will not show any links between pages. If you'd like to also see links, use this workflow:
 
-1. Add roxygen comments to your `.R` files. 
+1. Add roxygen comments to your `.R` files.
 
 1. Click `r oldbookdown::screenshot("screenshots/build-reload.png", dpi = 220)`
    in the build pane or press Ctrl/Cmd + Shift + B. This completely rebuilds the 

--- a/man.rmd
+++ b/man.rmd
@@ -88,6 +88,47 @@ When you use `?add`, `help("add")`, or `example("add")`, R looks for an `.Rd` fi
 oldbookdown::screenshot("screenshots/man-add.png", dpi = 220)
 ```
 
+To facilitate with the task of creating the documentation from scratch you can use the [sinew](https://github.com/metrumresearchgroup/sinew) package. This package creates a skeleton of the relevant populated fields with information scraped from the within the function script. Important details will automatically be added to the documentation such as: default values for parameters, importing definitions for the namespace, setting up links in the seealso field and defining the rdname for reusability. 
+
+For example the `stats::lm` function has 14 parameters to define and calls a function from the `stats` library inside of the script. The output of `sinew::makeOxygen` returns roxygen comments with information gleaned from within the script ready for final editing. 
+
+```r
+install.package('sinew')
+
+sinew::makeOxygen(lm)
+#' @title FUNCTION_TITLE
+#' @description FUNCTION_DESCRIPTION
+#' @param formula PARAM_DESCRIPTION
+#' @param data PARAM_DESCRIPTION
+#' @param subset PARAM_DESCRIPTION
+#' @param weights PARAM_DESCRIPTION
+#' @param na.action PARAM_DESCRIPTION
+#' @param method PARAM_DESCRIPTION, Default: 'qr'
+#' @param model PARAM_DESCRIPTION, Default: TRUE
+#' @param x PARAM_DESCRIPTION, Default: FALSE
+#' @param y PARAM_DESCRIPTION, Default: FALSE
+#' @param qr PARAM_DESCRIPTION, Default: TRUE
+#' @param singular.ok PARAM_DESCRIPTION, Default: TRUE
+#' @param contrasts PARAM_DESCRIPTION, Default: NULL
+#' @param offset PARAM_DESCRIPTION
+#' @param ... PARAM_DESCRIPTION
+#' @return OUTPUT_DESCRIPTION
+#' @details DETAILS
+#' @examples 
+#' \dontrun{
+#' if(interactive()){
+#'  #EXAMPLE1
+#'  }
+#' }
+#' @seealso 
+#'  \code{\link[stats]{model.frame}}
+#' @rdname lm
+#' @export 
+#' @importFrom stats model.frame
+```
+
+
+
 (Note you can preview development documentation because devtools overrides the usual help functions to teach them how to work with source packages. If the documentation doesn't appear, make sure that you're using devtools and that you've loaded the package with `devtools::load_all()`.)
 
 ## Alternative documentation workflow {#man-workflow-2}
@@ -96,18 +137,15 @@ The first documentation workflow is very fast, but it has one limitation: the pr
 
 1. Add roxygen comments to your `.R` files. 
 
-  - To facilitate this you can use the [sinew](https://github.com/metrumresearchgroup/sinew) package to create a skeleton of the relevant populated fields with information scraped
-  from the within the function script.
-
-2. Click `r oldbookdown::screenshot("screenshots/build-reload.png", dpi = 220)`
+1. Click `r oldbookdown::screenshot("screenshots/build-reload.png", dpi = 220)`
    in the build pane or press Ctrl/Cmd + Shift + B. This completely rebuilds the 
    package, including updating all the documentation, installs it in your
    regular library, then restarts R and reloads your package. This is 
    slow but thorough.
 
-3. Preview documentation with `?`.
+1. Preview documentation with `?`.
 
-4. Rinse and repeat until the documentation looks the way you want.
+1. Rinse and repeat until the documentation looks the way you want.
 
 If this workflow doesn't seem to be working, check your project options in RStudio. Old versions of devtools and RStudio did not automatically update the documentation when the package was rebuilt:
 

--- a/man.rmd
+++ b/man.rmd
@@ -88,7 +88,7 @@ When you use `?add`, `help("add")`, or `example("add")`, R looks for an `.Rd` fi
 oldbookdown::screenshot("screenshots/man-add.png", dpi = 220)
 ```
 
-To facilitate with the task of creating the documentation from scratch you can use the [sinew](https://github.com/metrumresearchgroup/sinew) package. This package creates a skeleton of the relevant populated fields with information scraped from the within the function script. Important details will automatically be added to the documentation such as: default values for parameters, importing definitions for the namespace, setting up links in the seealso field and defining the rdname for reusability. 
+To facilitate with the task of creating the documentation from scratch you can use the [sinew](https://github.com/metrumresearchgroup/sinew) package. This package creates a skeleton containing standard documentation fields populated with information scraped from the within the function script. Important details will automatically be added to the documentation such as: default values for parameters, importing definitions for the namespace, setting up links in the seealso field and defining the rdname for reusability. 
 
 For example the `stats::lm` function has 14 parameters to define and calls a function from the `stats` library inside of the script. The output of `sinew::makeOxygen` returns roxygen comments with information gleaned from within the script ready for final editing. 
 


### PR DESCRIPTION
[sinew](https://github.com/metrumresearchgroup/sinew) is lightweight package that helps users create consistent and informative `roxygen2` documentation. 

The overall goal of the package is to create documentation that will pass `devtools::check(build_args = '--as-cran')` and the user needs only to focus on writing descriptions for the fields.