### PR TITLE
Remove advice to ignore NEWS.md

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -381,7 +381,7 @@ This prevents `git commit` from succeeding unless `README.md` is more recent tha
 
 ### NEWS.md {#news}
 
-The `README.md` is aimed at new users. The `NEWS.md` is aimed at existing users: it should list all the API changes in each release. There are a number of formats you can use for package news, but I recommend `NEWS.md`. It's not supported by CRAN (so you'll need to run `devtools::use_build_ignore("NEWS.md")`), but it's well supported by GitHub and is easy to re-purpose for other formats.
+The `README.md` is aimed at new users. The `NEWS.md` is aimed at existing users: it should list all the API changes in each release. There are a number of formats you can use for package news, but I recommend `NEWS.md`. It's well supported by GitHub, permitted by CRAN, and is easy to re-purpose for other formats.
 
 Organise your `NEWS.md` as follows:
 


### PR DESCRIPTION
Devtools now has this warning:

    NEWS.md now supported by CRAN and doesn't need to be ignored