### PR TITLE
mention link style \link[pkg:bar]{foo}

### DIFF
--- a/man.rmd
+++ b/man.rmd
@@ -503,6 +503,8 @@ To other documentation:
 
 * `\link[=dest]{name}`: link to dest, but show name.
 
+* `\code{\link[MASS:abbey]{name}}`: link to function in another package, but show name.
+
 * `\linkS4class{abc}`: link to an S4 class.
 
 To the web:


### PR DESCRIPTION
This link style is documented at https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Cross_002dreferences.

I assign the copyright of this contribution to Hadley Wickham.