### PR TITLE
Change duplicate section anchors in Git and GitHub ch.

### DIFF
--- a/git.rmd
+++ b/git.rmd
@@ -55,7 +55,7 @@ Don't worry if you've never used the shell before because it's very similar to u
 
 If you've never used the shell before, I recommend playing [Terminus](http://web.mit.edu/mprat/Public/web/Terminus/Web/main.html). It's a fun way to learn the basics of the shell. I also recommend taking a look at Philip Guo's [Basic Unix-like command line tutorial](http://pgbovine.net/command-line-tutorial.htm) videos, and at <http://www.ee.surrey.ac.uk/Teaching/Unix/unix1.html> and <https://p1k3.com/userland-book/>.
 
-## Initial set up {#git-init}
+## Initial set up {#git-setup}
 
 If you've never used Git or GitHub before, start by installing Git and creating a GitHub account. Then, link the two together:
 
@@ -106,7 +106,7 @@ If you've never used Git or GitHub before, start by installing Git and creating 
     The easiest way to find the key is to click "View public key" in
     RStudio's Git/SVN preferences pane.
 
-## Create a local Git repository {#git-local}
+## Create a local Git repository {#git-init}
 
 Now that you have installed and configured Git, you can use it! To use GitHub with your package, you'll need to initialise a local repository, or __repo__ for short. This creates a `.git` directory that stores configuration files and a database that records changes to your code. A new repo exists only on your computer; you'll learn how to share it with others shortly.
 

--- a/git.rmd
+++ b/git.rmd
@@ -106,7 +106,7 @@ If you've never used Git or GitHub before, start by installing Git and creating 
     The easiest way to find the key is to click "View public key" in
     RStudio's Git/SVN preferences pane.
 
-## Create a local Git repository {#git-init}
+## Create a local Git repository {#git-local}
 
 Now that you have installed and configured Git, you can use it! To use GitHub with your package, you'll need to initialise a local repository, or __repo__ for short. This creates a `.git` directory that stores configuration files and a database that records changes to your code. A new repo exists only on your computer; you'll learn how to share it with others shortly.
 


### PR DESCRIPTION
Change anchor for "Create a local Git repository" to `{#git-local}`. Was `{git-init}`, the same as the preceding section, so the sidebar navigation takes you to "Initial set up."