### PR TITLE
Corrected typo

### DIFF
--- a/man.rmd
+++ b/man.rmd
@@ -302,7 +302,7 @@ It's relatively straightforward to document classes, generics and methods. The d
 
 S3 __generics__ are regular functions, so document them as such. S3 __classes__ have no formal definition, so document the constructor function. It is your choice whether or not to document S3 __methods__. You don't need to document methods for simple generics like `print()`. But if your method is more complicated or includes additional arguments, you should document it so people know how it works. In base R, you can see examples of documentation for more complex methods like `predict.lm()`, `predict.glm()`, and `anova.glm()`.
 
-Older versions of roxygen required explicit `@method generic class` tags for all S3 methods. From version 3.0.0 onward, this is no longer needed as roxygen2 will figure it out automatically. If you are upgrading, make sure to remove these old tags. Automatic method detection will only fail if the generic and class are ambiguous. For example is `all.equal.data.frame()` the `equal.data.frame` method for `all`, or the `data.frame` method for `all.equal`?. If this happens, you can disambiguate with e.g. `@method all.equal data.frame`.
+Older versions of roxygen required explicit `@method generic class` tags for all S3 methods. From version 3.0.0 onward, this is no longer needed as roxygen2 will figure it out automatically. If you are upgrading, make sure to remove these old tags. Automatic method detection will only fail if the generic and class are ambiguous. For example, is `all.equal.data.frame()` the `equal.data.frame` method for `all`, or the `data.frame` method for `all.equal`? If this happens, you can disambiguate with e.g. `@method all.equal data.frame`.
 
 ### S4 {#man-s4}
 


### PR DESCRIPTION
Changed, on line 305: From "For example is `all.equal.data.frame()` the `equal.data.frame` method for `all`, or the `data.frame` method for `all.equal`?." to "For example, is `all.equal.data.frame()` the `equal.data.frame method` for `all`, or the `data.frame` method for `all.equal`?", i.e., added a comma after sentence introduction and removed the extra period.