### PR TITLE
do *not* recommend full stop at end of title

### DIFF
--- a/man.rmd
+++ b/man.rmd
@@ -122,7 +122,7 @@ Each block includes some text before the first tag.[^1] This is called the __int
 
 * The first _sentence_ becomes the title of the documentation. That's what you 
   see when you look at `help(package = mypackage)` and is shown at the top of 
-  each help file. It should fit on one line, be written in sentence case, and 
+  each help file. It should fit on one line, be written in sentence case, but not 
   end in a full stop.
   
 * The second _paragraph_ is the description: this comes first in the 


### PR DESCRIPTION
This is to follow the tidyverse style guide: http://style.tidyverse.org/code-documentation.html#title-and-description.

I assign the copyright of this contribution to Hadley Wickham.