### PR TITLE
remove full stops at ends of titles

### DIFF
--- a/data.rmd
+++ b/data.rmd
@@ -66,7 +66,7 @@ You can see this approach in practice in some of my recent data packages. I've b
 Objects in `data/` are always effectively exported (they use a slightly different mechanism than `NAMESPACE`'s but the details are not important). This means that they must be documented. Documenting data is like documenting a function with a few minor differences. Instead of documenting the data directly, you document the name of the dataset and save it in `R/`. For example, the roxygen2 block used to document the diamonds data in ggplot2 is saved as `R/data.R` and looks something like this:
 
 ```{r, eval = FALSE}
-#' Prices of 50,000 round cut diamonds.
+#' Prices of 50,000 round cut diamonds
 #'
 #' A dataset containing the prices and other attributes of almost 54,000
 #' diamonds.

--- a/man.rmd
+++ b/man.rmd
@@ -40,7 +40,7 @@ In this section, we'll first go over a rough outline of the complete documentati
 The process starts when you add roxygen comments to your source file: roxygen comments start with `#'` to distinguish them from regular comments. Here's documentation for a simple function:
 
 ```{r}
-#' Add together two numbers.
+#' Add together two numbers
 #' 
 #' @param x A number.
 #' @param y A number.
@@ -137,7 +137,7 @@ All objects must have a title and description. Details are optional.
 Here's an example showing what the introduction for `sum()` might look like if it had been written with roxygen:
 
 ```{r}
-#' Sum of vector elements.
+#' Sum of vector elements
 #' 
 #' \code{sum} returns the sum of all the values present in its arguments.
 #' 
@@ -232,7 +232,7 @@ Functions are the most commonly documented object. As well as the introduction b
 We could use these new tags to improve our documentation of `sum()` as follows:
 
 ```{r}
-#' Sum of vector elements.
+#' Sum of vector elements
 #'
 #' \code{sum} returns the sum of all the values present in its arguments.
 #'
@@ -279,7 +279,7 @@ You can use roxygen to provide a help page for your package as a whole. This is 
 There's no object that corresponds to a package, so you need to document `NULL`, and then manually label it with `@docType package` and `@name <package-name>`. This is also an excellent place to use the `@section` tag to divide up page into useful categories.
 
 ```{r}
-#' foo: A package for computating the notorious bar statistic.
+#' foo: A package for computating the notorious bar statistic
 #'
 #' The foo package provides three categories of important functions:
 #' foo, bar and baz.
@@ -309,7 +309,7 @@ Older versions of roxygen required explicit `@method generic class` tags for all
 Document __S4 classes__ by adding a roxygen block before `setClass()`. Use `@slot` to document the slots of the class in the same way you use `@param` to describe the parameters of a function. Here's a simple example:
 
 ```{r}
-#' An S4 class to represent a bank account.
+#' An S4 class to represent a bank account
 #'
 #' @slot balance A length-one numeric vector
 Account <- setClass("Account",
@@ -355,7 +355,7 @@ Older versions of roxygen2 required explicit `@usage`, `@alias` and `@docType` t
 Reference classes are different to S3 and S4 because methods are associated with classes, not generics. RC also has a special convention for documenting methods: the __docstring__. The docstring is a string placed inside the definition of the method which briefly describes what it does. This makes documenting RC simpler than S4 because you only need one roxygen block per class.
 
 ```{r}
-#' A Reference Class to represent a bank account.
+#' A Reference Class to represent a bank account
 #'
 #' @field balance A length-one numeric vector.
 Account <- setRefClass("Account",


### PR DESCRIPTION
After merging #469, the new recommendation of not putting full stops at the ends of titles should be applied to all code examples. This pull request does that.

Note that very strictly speaking, the relevant section of the tidyverse style guide only mentions functions and not datasets or other objects. But I strongly suspect that the "no full stop" rule is meant to apply to all these objects.

I assign the copyright of this contribution to Hadley Wickham.