### PR TITLE
Change has_devel() to has_compiler() in intro.rmd

### DIFF
--- a/intro.rmd
+++ b/intro.rmd
@@ -147,7 +147,7 @@ You can check that you have everything installed and working by running the foll
 
 ```{r, eval = FALSE}
 library(devtools)
-has_devel()
+pkgbuild::has_compiler()
 #> '/Library/Frameworks/R.framework/Resources/bin/R' --vanilla CMD SHLIB foo.c 
 #> 
 #> clang -I/Library/Frameworks/R.framework/Resources/include -DNDEBUG 


### PR DESCRIPTION
Couldn't find any has_devel() following the instructions given. Instead I found has_compiler() under `pkgbuild`