### PR TITLE
Updated requireNamespace()

### DIFF
--- a/namespace.rmd
+++ b/namespace.rmd
@@ -91,7 +91,7 @@ Of the four, you should only ever use two:
   package is not installed, and will terminate the script. You want to attach 
   the package to save typing. Never use `library()` in a package.
   
-* Use `requireNamespace(x, quietly = TRUE)` inside a package if you want a
+* Use `requireNamespace("x", quietly = TRUE)` inside a package if you want a
   specific action (e.g. throw an error) depending on whether or not
   a suggested package is installed.
   


### PR DESCRIPTION
`requireNamespace(x, quitely = TRUE)` will not work, since the first argument must be a string. Added quotes around `x`.