### PR TITLE
Move `context()` call after `library()` call

### DIFF
--- a/tests.rmd
+++ b/tests.rmd
@@ -100,8 +100,8 @@ Each failure gives a description of the test (e.g., "Variance correct for discre
 A test file lives in `tests/testthat/`. Its name must start with `test`. Here's an example of a test file from the stringr package:
 
 ```{r}
-library(stringr)
 context("String length")
+library(stringr)
 
 test_that("str_length is number of characters", {
   expect_equal(str_length("a"), 1)


### PR DESCRIPTION
Having the `library()` call first gives you an error in the CRAN version of testthat.

Fixes https://github.com/r-lib/testthat/issues/700#issuecomment-379578564