### PR TITLE
Nonstandard author roles may raise a NOTE

### DIFF
--- a/description.rmd
+++ b/description.rmd
@@ -237,7 +237,7 @@ This command says that both the author (aut) and the maintainer (cre) is Hadley 
     (The [full list of roles](http://www.loc.gov/marc/relators/relaterm.html) is
     extremely comprehensive. Should your package have a woodcutter ("wdc"), 
     lyricist ("lyr") or costume designer ("cst"), rest comfortably that you can 
-    correctly describe their role in creating your package.)
+    correctly describe their role in creating your package. Beware using some non-standard role will raise, during CRAN checks, a NOTE with a blank explanation as a result at the checking DESCRIPTION meta-information step !)
 
 If you need to add further clarification, you can also use the `comment` argument and supply the desired information in plain text.
 


### PR DESCRIPTION
Warn against the use of nonstandard roles in the Authors@R field of the DESCRIPTION file since it may raise a NOTE with a blank line as explanation.
* checking DESCRIPTION meta-information ... NOTE