### PR TITLE
replace deprecated command 'devtools::create'

### DIFF
--- a/package.rmd
+++ b/package.rmd
@@ -80,7 +80,7 @@ Once you've come up with a name, there are two ways to create the package. You c
 Alternatively, you can create a new package from within R by running
 
 ```{r, eval = FALSE}
-devtools::create("path/to/package/pkgname")
+usethis::create_package("path/to/package/pkgname")
 ```
     
 Either route gets you to the same place: the smallest usable package, one with three components:


### PR DESCRIPTION
'devtools::create' and related commands ('setup', 'create_description', 'use_rstudio') are deprecated, according to the warning messages I got, eg: 
"1: 'devtools::create' is deprecated.
Use 'usethis::create_package()' instead."

the readme files are also consistent with this
https://github.com/r-lib/devtools
https://github.com/r-lib/usethis

hope I didn't misunderstand something!