### PR TITLE
Minor change

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -58,7 +58,7 @@ There are good reasons to make backward incompatible changes - if you made a des
     whenever someone uses the function:
   
     ```{r}
-    # 0.1.0
+    # 0.6.0
     fun <- function(x, y, z) {
       .Deprecated("sum")
       x + y + z


### PR DESCRIPTION
Matching version number of example code with surounding text ("For example, imagine your package is version `0.5.0` and you want to remove `fun()`. In version, `0.6.0`, you'd use `.Deprecated()` to display a warning message whenever someone uses the function").

I assign the copyright of this contribution to Hadley Wickham