### PR TITLE
add three spaces for demo description

### DIFF
--- a/misc.rmd
+++ b/misc.rmd
@@ -32,7 +32,7 @@ You list and access demos with `demo()`:
 * Run a specific demo: `demo("oauth1-twitter", package = "httr")`.
 * Find a demo: `system.file("demo", "oauth1-twitter.R", package = "httr")`.
 
-Each demo must be listed in `demo/00Index` in the following form: `demo-name  Demo description`. The demo name is the name of the file without the extension, e.g. `demo/my-demo.R` becomes `my-demo`.
+Each demo must be listed in `demo/00Index` in the following form: `demo-name   Demo description`. The demo name is the name of the file without the extension, e.g. `demo/my-demo.R` becomes `my-demo`.
 
 By default the demo asks for human input for each plot: "Hit <Return> to see next plot: ". 
 This behaviour can be overridden by adding `devAskNewPage(ask = FALSE)` to the demo file.


### PR DESCRIPTION
This is from the guidelines:

" If present, the demo subdirectory should also have a 
00Index file with one line for each demo, giving its name 
and a description separated by a tab or at least three spaces."