### PR TITLE
Delete strange symbol

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -72,7 +72,7 @@ The first few lines of the vignette contain important metadata. The default temp
     ---
     title: "Vignette Title"
     author: "Vignette Author"
-    date: "`r Sys.Date()`"
+    date: "`r Sys.Date()`"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}


### PR DESCRIPTION
A symbol that renders as a musical note was in the vignette metadata