### PR TITLE
Update release.rmd

### DIFF
--- a/release.rmd
+++ b/release.rmd
@@ -215,7 +215,7 @@ When checking your package you need to make sure that it passed with the current
 
 It's painful to manage multiple R versions, especially since you'll need to reinstall all your packages. Instead, you can run `R CMD check` on CRAN's servers with `devtools::build_win()`.  This builds your package and submits it to the CRAN win-builder. 10-20 minutes after submission, you'll receive an e-mail telling you the check results.
 
-CRAN runs on multiple platforms: Windows, Mac OS X, Linux and Solaris. You don't need to run `R CMD check` on every one of these platforms, but it's a really good idea to do it on at least two. This increases your chances of spotting code that relies on the idiosyncrasies of specific platform. If you're on Linux or Mac, use `devtools::build_win()` to check on Windows. If you're on Windows, use Travis, as described in [continuous integration with Travis](#travis), to run checks on Linux.
+CRAN runs on multiple platforms: Windows, Mac OS X, Linux and Solaris. You don't need to run `R CMD check` on every one of these platforms, but it's a really good idea to do it on at least two. This increases your chances of spotting code that relies on the idiosyncrasies of specific platform. If you're on Linux or Mac, use `devtools::check_win_*()` to check on Windows. If you're on Windows, use Travis, as described in [continuous integration with Travis](#travis), to run checks on Linux.
 
 Debugging code that works on your computer but fails elsewhere is painful. If that happens to you, either install a virtualisation tool so that you can run another operating system locally, or find a friend to help you figure out the problem. Don't submit the package and hope CRAN will help you figure out the problem.
 


### PR DESCRIPTION
replaced `devtools::build_win()` by `devtools::check_win_*()` at line 218.