### PR TITLE
system.file add arg mustWork +  devtools::use_vignette is deprecated

### DIFF
--- a/data.rmd
+++ b/data.rmd
@@ -114,12 +114,17 @@ If you want to show examples of loading/parsing raw data, put the original files
 system.file("extdata", "2012.csv", package = "testdat")
 ```
 
-Beware: if the file does not exist, `system.file()` does not return an error - it just returns the empty string:
+Beware: by default, if the file does not exist, `system.file()` does not return an error - it just returns the empty string:
 
 ```{r}
 system.file("extdata", "2010.csv", package = "testdat")
 ```
 
+If you want to have an error message when the file does not exist, add the argument `mustWork = TRUE`:
+
+```{r, error = TRUE}
+system.file("extdata", "2010.csv", package = "testdat", mustWork = TRUE)
+```
 ## Other data {#other-data}
 
 * Data for tests: it's ok to put small files directly in your test directory.

--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -35,7 +35,7 @@ Currently, the easiest way to get R Markdown is to use [RStudio](http://www.rstu
 To create your first vignette, run:
 
 ```{r, eval = FALSE}
-devtools::use_vignette("my-vignette")
+usethis::use_vignette("my-vignette")
 ```
 
 This will:


### PR DESCRIPTION
- When using system.file, use mustWork = TRUE to have an error message 
- devtools::use_vignette is deprecadted

I assign the copyright of this contribution to Hadley Wickham