### PR TITLE
devtools::use_testthat() is deprecated in tests

### DIFF
--- a/tests.rmd
+++ b/tests.rmd
@@ -56,7 +56,7 @@ If you're familiar with unit testing in other languages, you should note that th
 To set up your package to use testthat, run:
 
 ```{r, eval = FALSE}
-devtools::use_testthat()
+usethis::use_testthat()
 ```
 
 This will:


### PR DESCRIPTION
Replaced the usage with usethis::use_testthat() as recommended from the deprecated message