### PR TITLE
Typos and updating to latest output in Vignettes

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -35,7 +35,7 @@ Currently, the easiest way to get R Markdown is to use [RStudio](http://www.rstu
 To create your first vignette, run:
 
 ```{r, eval = FALSE}
-devtools::use_vignette("my-vignette")
+usethis::use_vignette("my-vignette")
 ```
 
 This will:
@@ -72,12 +72,12 @@ The first few lines of the vignette contain important metadata. The default temp
     ---
     title: "Vignette Title"
     author: "Vignette Author"
-    date: "`r Sys.Date()`"
+    date: "`r Sys.Date()`"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}
       %\VignetteEngine{knitr::rmarkdown}
-      \usepackage[utf8]{inputenc}
+      %\VignetteEncoding{UTF-8}
     ---
 
 This metadata is written in [yaml](http://www.yaml.org/), a format designed to be both human and computer readable. The basics of the syntax is much like the `DESCRIPTION` file, where each line consists of a field name, a colon, then the value of the field. The one special YAML feature we're using here is `>`. It indicates the following lines of text are plain text and shouldn't use any special YAML features.
@@ -234,7 +234,7 @@ Knitr allows you to intermingle code, results and text. Knitr takes R code, runs
 
 Consider the simple example below. Note that a knitr block looks similar to a fenced code block, but instead of using `r`, you are using `{r}`.
 
-    ```{r}
+    ```{r}
     # Add two numbers together
     add <- function(a, b) a + b
     add(10, 20)
@@ -266,13 +266,13 @@ You can specify additional options to control the rendering:
 
 * To affect a single block, add the block settings:
 
-        ```{r, opt1 = val1, opt2 = val2}
+        ```{r, opt1 = val1, opt2 = val2}
         # code
         ```
   
 * To affect all blocks, call `knitr::opts_chunk$set()` in a knitr block:
     
-        ```{r, echo = FALSE}
+        ```{r, echo = FALSE}
         knitr::opts_chunk$set(
           opt1 = val1,
           opt2 = val2
@@ -309,7 +309,7 @@ The most important options are:
   code output. I usually set these globally by putting the following knitr
   block at the start of my document.
 
-        ```{r, echo = FALSE}
+        ```{r, echo = FALSE}
         knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
         ```
 
@@ -317,7 +317,7 @@ The most important options are:
     This is useful if you want to generate text from your R code. For example,
     if you want to generate a table using the pander package, you'd do:
   
-        ```{r, results = "asis"}
+        ```{r, results = "asis"}
         pander::pandoc.table(iris[1:3, 1:4])
         ```
     
@@ -354,7 +354,7 @@ Many other options are described at <http://yihui.name/knitr/options>.
 
 ## Development cycle {#vignette-workflow-2}
 
-Run code a chunk at a time using Cmd + Alt + C. Re-run the entire document in a fresh R session using Knit (Ctrl/Cmd + Shift + K). 
+Run code a chunk at a time using Ctrl/Cmd + Alt + C. Re-run the entire document in a fresh R session using Knit (Ctrl/Cmd + Shift + K). 
 
 You can build all vignettes from the console with `devtools::build_vignettes()`, but this is rarely useful. Instead use `devtools::build()` to create a package bundle with the vignettes included.  RStudio's "Build & reload" does not build vignettes to save time. Similarly, `devtools::install_github()` (and friends) will not build vignettes by default because they're time consuming and may require additional packages. You can force building with `devtools::install_github(build_vignettes = TRUE)`. This will also install all suggested packages.
 


### PR DESCRIPTION
devtools::use_vignette is deprecated, so replaced with the recommended one. Removed some magic characters occasionally appearing next to `s. Updated template vignette generated to reflect to what is actually is generated when using latest version of packages