### PR TITLE
Replace deprecated devtools call

### DIFF
--- a/vignettes.rmd
+++ b/vignettes.rmd
@@ -35,7 +35,7 @@ Currently, the easiest way to get R Markdown is to use [RStudio](http://www.rstu
 To create your first vignette, run:
 
 ```{r, eval = FALSE}
-devtools::use_vignette("my-vignette")
+usethis::use_vignette("my-vignette")
 ```
 
 This will:


### PR DESCRIPTION
`devtools::use_vignette` has a deprecation warning and then calls `usethis::use_vignette`; reflecting that here