### PR TITLE
Fix wrong argument suggestion.

### DIFF
--- a/data.rmd
+++ b/data.rmd
@@ -32,7 +32,7 @@ x <- sample(1000)
 devtools::use_data(x, mtcars)
 ```
 
-It's possible to use other types of files, but I don't recommend it because `.RData` files are already fast, small and explicit. Other options are described in `data()`. For larger datasets, you may want to experiment with the compression setting. The default is `bzip2`, but sometimes `gzip` or `xz` can create smaller files (typically at the expense of slower loading times).
+It's possible to use other types of files, but I don't recommend it because `.RData` files are already fast, small and explicit. Other options are described in `data()`. For larger datasets, you may want to experiment with the compression setting. The default is `bzip2`, but sometimes `gzip` or `xz` cost less compression/decompression time (typically with larger file size).
 
 If the `DESCRIPTION` contains `LazyData: true`, then datasets will be lazily loaded. This means that they won't occupy any memory until you use them. The following example shows memory usage before and after loading the nycflights13 package. You can see that memory usage doesn't change until you inspect the flights dataset stored inside the package. 
 


### PR DESCRIPTION
`gizp` and `xz` is faster than `bzip2`. For more detail, read https://www.rootusers.com/gzip-vs-bzip2-vs-xz-performance-comparison/