### PR TITLE
Replace mention of .Rd files with NAMESPACE file

### DIFF
--- a/namespace.Rmd
+++ b/namespace.Rmd
@@ -160,7 +160,7 @@ Generating the namespace with roxygen2 is just like generating function document
 1. Add roxygen comments to your `.R` files.
 
 1. Run `devtools::document()` (or press Ctrl/Cmd + Shift + D in RStudio) to 
-   convert roxygen comments to `.Rd` files.
+   generate the `NAMESPACE` file from roxygen comments.
 
 1. Look at `NAMESPACE` and run tests to check that the specification is
    correct.


### PR DESCRIPTION
Replace mention of .Rd files with NAMESPACE file in Roxygen workflow.
I assign the copyright of this contribution to Hadley Wickham.