### PR TITLE
Correctly applying the proposed punctuation in the examples

### DIFF
--- a/man.Rmd
+++ b/man.Rmd
@@ -38,7 +38,7 @@ In this section, we'll first go over a rough outline of the complete documentati
 The process starts when you add roxygen comments to your source file: roxygen comments start with `#'` to distinguish them from regular comments. Here's documentation for a simple function:
 
 ```{r}
-#' Add together two numbers.
+#' Add together two numbers
 #' 
 #' @param x A number.
 #' @param y A number.
@@ -62,9 +62,9 @@ Pressing Ctrl/Cmd + Shift + D (or running `devtools::document()`) will generate 
 add(x, y)
 }
 \arguments{
-  \item{x}{A number}
+  \item{x}{A number.}
 
-  \item{y}{A number}
+  \item{y}{A number.}
 }
 \value{
 The sum of \code{x} and \code{y}
@@ -136,7 +136,7 @@ All objects must have a title and description. Details are optional.
 Here's an example showing what the introduction for `sum()` might look like if it had been written with roxygen:
 
 ```{r}
-#' Sum of vector elements.
+#' Sum of vector elements
 #' 
 #' \code{sum} returns the sum of all the values present in its arguments.
 #' 
@@ -231,7 +231,7 @@ Functions are the most commonly documented object. As well as the introduction b
 We could use these new tags to improve our documentation of `sum()` as follows:
 
 ```{r}
-#' Sum of vector elements.
+#' Sum of vector elements
 #'
 #' \code{sum} returns the sum of all the values present in its arguments.
 #'
@@ -398,10 +398,10 @@ There is a tension between the DRY (don't repeat yourself) principle of programm
 You can inherit parameter descriptions from other functions using `@inheritParams source_function`. This tag will bring in all documentation for parameters that are undocumented in the current function, but documented in the source function. The source can be a function in the current package, via `@inheritParams function`, or another package, via `@inheritParams package::function`. For example the following documentation:
 
 ```{r}
-#' @param a This is the first argument
+#' @param a This is the first argument.
 foo <- function(a) a + 10
 
-#' @param b This is the second argument
+#' @param b This is the second argument.
 #' @inheritParams foo
 bar <- function(a, b) {
   foo(a) * 10
@@ -411,8 +411,8 @@ bar <- function(a, b) {
 is equivalent to
 
 ```{r}
-#' @param a This is the first argument
-#' @param b This is the second argument
+#' @param a This is the first argument.
+#' @param b This is the second argument.
 bar <- function(a, b) {
   foo(a) * 10
 }


### PR DESCRIPTION
The guidelines say that titles _should not_ end in a full stop, and parameter descriptions _should_ end in a full stop. Several examples in this chapter violated against this rule, some fixes are proposed.

It remains to be further evaluated by the authors whether this must also hold for object documentation, in this chapter (this commit does not fix that, however the book is unclear about that).

Thanks for keeping up the great work. And with pleasure, 'I assign the copyright of this contribution to Hadley Wickham' :-)