### PR TITLE
write fcount_fodder to fcount.R (not fcount_fodder.R)

### DIFF
--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -614,7 +614,7 @@ cat(fcount_fodder, sep = "\n")
 ```
 
 ```{r write-fcount, include = FALSE, eval = create}
-writeLines(fcount_fodder, path("R", "fcount_fodder.R"))
+writeLines(fcount_fodder, path("R", "fcount.R"))
 ```
 
 Notice how we preface the call to a forcats functions with `forcats::`. This specifies that we want to call the `fct_count()` function from the forcats namespace. There is more than one way to call functions in other packages and the one we espouse here is explained fully in chapter \@ref(namespace).


### PR DESCRIPTION
Hi @jennybc,

I *think* this is a typo in the Whole Game chapter, in the [section](https://r-pkgs.org/whole-game.html#use_package) where you demo `use_package`.

This is the reason `fcount.R` is empty here: 
https://github.com/jennybc/foofactors/blob/master/R/fcount.R

But you do have `fcount_fodder.R` here: 
https://github.com/jennybc/foofactors/blob/master/R/fcount_fodder.R

See this [commit](https://github.com/jennybc/foofactors/commit/83ee478061e5234805f76b1e2c488e79a2628588).

Alison