### PR TITLE
correct Authors field in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: r-pkgs
 Title: R Packages
 Version: 0.1
 Authors@R: c(
-  person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")),
+  person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre"))
   )
 URL: http://r-pkgs.had.co.nz/
 Imports:


### PR DESCRIPTION
```
R CMD INSTALL .
...
Error : Invalid DESCRIPTION file

Malformed Authors@R field:
  argument 2 is empty

Malformed package name

See section 'The DESCRIPTION file' in the 'Writing R Extensions'
manual.

ERROR: installing package DESCRIPTION failed for package ‘r-pkgs’
```

