### PR TITLE
update minimum rstudioapi version to currently released version

### DIFF
--- a/intro.Rmd
+++ b/intro.Rmd
@@ -117,7 +117,7 @@ Make sure you have a recent version of RStudio. You can check you have the right
 
 ```{r, eval = FALSE}
 install.packages("rstudioapi")
-rstudioapi::isAvailable("0.99.149")
+rstudioapi::isAvailable("1.2.1335")
 ```
 
 If not, you may need to install the preview version from <http://www.rstudio.com/products/rstudio/download/preview/>. This gives you access to the latest and greatest features, and only slightly increases your chances of finding a bug. 


### PR DESCRIPTION
Increase minimum rstudioapi version at least to currently released version [`1.2.1335`](https://www.rstudio.com/products/rstudio/release-notes/). Which was released at about the same time as the required minimum R version 3.6.0.

I assign the copyright of this contribution to Hadley Wickham.