### PR TITLE
structure.Rmd: Image files not shown in the book

### DIFF
--- a/structure.Rmd
+++ b/structure.Rmd
@@ -142,9 +142,13 @@ PackageRoxygenize: rd,collate,namespace
 
 You don't need to modify this file by hand. Instead, use the friendly project options dialog box, accessible from the projects menu in the top-right corner of RStudio.
 
-
-<img width = "30%" src = "images/project-options-1.png"/><img width = "70%" src = "images/project-options-2.png"/>
-
+```{r, echo = FALSE, out.width="30%"}
+knitr::include_graphics("images/project-options-1.png")
+```
+```{r, echo = FALSE, out.width="70%"}
+knitr::include_graphics("images/project-options-2.png")
+```
+    
 ## What is a package? {#package}
 
 To make your first package, all you need to know is what you've learnt above. To master package development, particularly when you're distributing a package to others, it really helps to understand the five states a package can be in across its lifecycle: source, bundled, binary, installed and in-memory. Understanding the differences between these states will help you form a better mental model of what `install.packages()` and `devtools::install_github()` do, and will make it easier to debug problems when they arise.


### PR DESCRIPTION
The following code does not allow to render images in the book
```
<img width = "30%" src = "images/project-options-1.png"/><img width = "70%" src = "images/project-options-2.png"/>
```
I suggest using `knitr::include_graphics()` as in the rest of the book.
If the two images need to be side by side, it would be preferable to create a unique image.