### PR TITLE
Deleted a couple of lines from vignette metadata

### DIFF
--- a/vignettes.Rmd
+++ b/vignettes.Rmd
@@ -69,8 +69,6 @@ The first few lines of the vignette contain important metadata. The default temp
 
     ---
     title: "Vignette Title"
-    author: "Vignette Author"
-    date: "`r Sys.Date()`"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}


### PR DESCRIPTION
The default vignette (the one generated by usethis::use_vignette) doesn't include "author" and "date" info in YAML section