### PR TITLE
Clarify '16.6 Release' section

### DIFF
--- a/release.Rmd
+++ b/release.Rmd
@@ -423,8 +423,10 @@ You're now ready to submit your package to CRAN. The easiest way to do this is t
     can't otherwise be automated.
   
 * Uploads the package bundle to the 
-  [CRAN submission form](http://cran.r-project.org/submit.html), including entering the
-  contents in `cran-comments.md` into the 'Optional comment' field of the form.
+  [CRAN submission form](http://cran.r-project.org/submit.html), including
+  entering the contents in `cran-comments.md` into the 'Optional comment' field
+  of the form as plain text. The `cran-comments.md` file itself is not included
+  in the uploaded package if listed in `.Rbuildignore`.
 
 Within the next few minutes, you'll receive an email notifying you of the submission and asking you to approve it (this confirms that the maintainer address is correct). Next the CRAN maintainers will run their checks and get back to you with the results. This normally takes around 24 hours, but occasionally can take up to 5 days.
 

--- a/release.Rmd
+++ b/release.Rmd
@@ -423,8 +423,8 @@ You're now ready to submit your package to CRAN. The easiest way to do this is t
     can't otherwise be automated.
   
 * Uploads the package bundle to the 
-  [CRAN submission form](http://cran.r-project.org/submit.html) including the
-  comments in `cran-comments.md`.
+  [CRAN submission form](http://cran.r-project.org/submit.html), including entering the
+  contents in `cran-comments.md` into the 'Optional comment' field of the form.
 
 Within the next few minutes, you'll receive an email notifying you of the submission and asking you to approve it (this confirms that the maintainer address is correct). Next the CRAN maintainers will run their checks and get back to you with the results. This normally takes around 24 hours, but occasionally can take up to 5 days.
 


### PR DESCRIPTION
* Clarify how `cran-comments.md` is processed in **16.6 Release**.

I was confused about whether `cran-comments.md` is supposed to be included in the uploaded package bundle. I hope this clarifies it.

I assign the copyright of this contribution to Hadley Wickham.