### PR TITLE
remove suggestion about `as.person(...)`

### DIFF
--- a/metadata.Rmd
+++ b/metadata.Rmd
@@ -261,17 +261,6 @@ Authors@R: c(
     person("Winston", "Chang", email = "winston@rstudio.com", role = "aut"))
 ```
 
-Alternatively, you can do this concisely by using `as.person()`:
-
-```yaml
-Authors@R: as.person(c(
-    "Hadley Wickham <hadley@rstudio.com> [aut, cre]", 
-    "Winston Chang <winston@rstudio.com> [aut]"
-  ))
-```
-
-(This only works well for names with only one first and last name.)
-
 Every package must have at least one author (aut) and one maintainer (cre) (they might be the same person). The creator must have an email address. These fields are used to generate the basic citation for the package (e.g. `citation("pkgname")`). Only people listed as authors will be included in the auto-generated citation. There are a few extra details if you're including code that other people have written. Since this typically occurs when you're wrapping a C library, it's discussed in [compiled code](#src).
 
 As well as your email address, it's also a good idea to list other resources available for help. You can list URLs in `URL`. Multiple URLs are separated with a comma. `BugReports` is the URL where bug reports should be submitted. For example, knitr has:


### PR DESCRIPTION
Agree that `as.person` exists and works nicely, but per a rejected package update, CRAN now seems to require `person(...)` or `c(person(...), person(...), ...)`.  Using `as.person(...)` generates a note on their automated system:

```
* checking CRAN incoming feasibility ... NOTE
Authors@R field should be a call to person(), or combine such calls.
```