### PR TITLE
R_RegisterCCallable: package name instead of DLL pointer

### DIFF
--- a/src.Rmd
+++ b/src.Rmd
@@ -343,7 +343,7 @@ R solves this problem using __function registration__. To export a `.Call()` C f
 
 To register a function, call `R_RegisterCCallable()`, defined in `<R_ext/Rdynload.h>`. Function registration should be done in a function called `R_init_<mypackage>`. This function is called automatically when the "mypackage" DLL is loaded. `R_RegisterCCallable()` has three arguments:
 
-* A pointer to the DLL.
+* The name of the package.
 * The name of the function.
 * A pointer to the function, cast as `DL_FUNC` (i.e. a **d**ynamically 
   **l**oaded **func**tion).


### PR DESCRIPTION
`R_RegisterCCallable` takes the package name as its first argument, not the `DllInfo` pointer.