### PR TITLE
Replace all instances of vertical tab with unicode zero width spaces

### DIFF
--- a/release.Rmd
+++ b/release.Rmd
@@ -344,13 +344,13 @@ output: github_document
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-```{r, echo = FALSE}
+`​``{r, echo = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.path = "README-"
 )
-```
+`​``
 ```
 
 This:
@@ -391,8 +391,8 @@ Organise your `NEWS.md` as follows:
   It's hard to know in advance exactly what sections you'll need.
 
 * If an item is related to an issue in GitHub, include the issue number in
-  parentheses, e.g. `(#10)`. If an item is related to a pull request, include 
-  the pull request number and the author, e.g. `(#101, @hadley)`. Doing
+  parentheses, e.g. `(#​10)`. If an item is related to a pull request, include 
+  the pull request number and the author, e.g. `(#​101, @hadley)`. Doing
   this makes it easy to navigate to the relevant issues on GitHub.
 
 The main challenge with `NEWS.md` is getting into the habit of noting a change as you make a change. 

--- a/vignettes.Rmd
+++ b/vignettes.Rmd
@@ -230,7 +230,7 @@ Knitr allows you to intermingle code, results and text. Knitr takes R code, runs
 
 Consider the simple example below. Note that a knitr block looks similar to a fenced code block, but instead of using `r`, you are using `{r}`.
 
-    ```{r}
+    `​``{r}
     # Add two numbers together
     add <- function(a, b) a + b
     add(10, 20)
@@ -262,13 +262,13 @@ You can specify additional options to control the rendering:
 
 * To affect a single block, add the block settings:
 
-        ```{r, opt1 = val1, opt2 = val2}
+        `​``{r, opt1 = val1, opt2 = val2}
         # code
         ```
   
 * To affect all blocks, call `knitr::opts_chunk$set()` in a knitr block:
     
-        ```{r, echo = FALSE}
+        `​``{r, echo = FALSE}
         knitr::opts_chunk$set(
           opt1 = val1,
           opt2 = val2
@@ -305,7 +305,7 @@ The most important options are:
   code output. I usually set these globally by putting the following knitr
   block at the start of my document.
 
-        ```{r, echo = FALSE}
+        `​``{r, echo = FALSE}
         knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
         ```
 
@@ -313,7 +313,7 @@ The most important options are:
     This is useful if you want to generate text from your R code. For example,
     if you want to generate a table using the pander package, you'd do:
   
-        ```{r, results = "asis"}
+        `​``{r, results = "asis"}
         pander::pandoc.table(iris[1:3, 1:4])
         ```
     


### PR DESCRIPTION
The vertical tabs show up in the HTML as whitespace, the zero width
spaces do not

Fixes #597