### PR TITLE
s/devtools/revdepcheck/

### DIFF
--- a/release.Rmd
+++ b/release.Rmd
@@ -247,7 +247,7 @@ You've already learned how to use `R CMD check` and why it's important in [autom
 
 ### Reverse dependencies {#release-deps}
 
-Finally, if you're releasing a new version of an existing package, it's your responsibility to check that downstream dependencies (i.e. all packages that list your package in the `Depends`, `Imports`, `Suggests` or `LinkingTo` fields) continue to work. To help you do this, devtools provides `devtools::revdep_check()`. This:
+Finally, if you're releasing a new version of an existing package, it's your responsibility to check that downstream dependencies (i.e. all packages that list your package in the `Depends`, `Imports`, `Suggests` or `LinkingTo` fields) continue to work. To help you do this, devtools provides `revdepcheck::revdep_check()`. This:
 
 1. Sets up a temporary library so it doesn't clobber any existing packages you
    have installed.


### PR DESCRIPTION
Since `devtools` doesnt have revdep_check() anymore, we need to use revdepcheck instead.