### PR TITLE
minor grammar tweak

### DIFF
--- a/git.Rmd
+++ b/git.Rmd
@@ -306,7 +306,7 @@ knitr::include_graphics("images/git-ignore.png", dpi = 220)
 
 If you want to ignore multiple files, you can use a wildcard "glob" like `*.png`. To learn more about the options, see [ignoring files](http://git-scm.com/book/ch2-2.html#Ignoring-Files) in Pro-Git.
 
-Some developers never commit derived files, files that can be generated automatically. For an R package this would mean ignoring the files `NAMESPACE` and anything in the `man/` directory because they're generated from comments. From a practical pespective, it's better to commit these files: R packages have no way to generate `.Rd` files on installation so ignoring derived files means that users who install your package from GitHub will have no documentation.
+Some developers never commit derived files, files that can be generated automatically. For an R package this would mean ignoring the `NAMESPACE` file and anything in the `man/` directory because they're generated from comments. From a practical perspective, it's better to commit these files: R packages have no way to generate `.Rd` files on installation so ignoring derived files means that users who install your package from GitHub will have no documentation.
 
 ## Undo a mistake {#git-undo}
 

--- a/git.Rmd
+++ b/git.Rmd
@@ -306,7 +306,7 @@ knitr::include_graphics("images/git-ignore.png", dpi = 220)
 
 If you want to ignore multiple files, you can use a wildcard "glob" like `*.png`. To learn more about the options, see [ignoring files](http://git-scm.com/book/ch2-2.html#Ignoring-Files) in Pro-Git.
 
-Some developers never commit derived files, files that can be generated automatically. For an R package this would mean ignoring the files in the `NAMESPACE` and `man/` directories because they're generated from comments. From a practical pespective, it's better to commit these files: R packages have no way to generate `.Rd` files on installation so ignoring derived files means that users who install your package from GitHub will have no documentation.
+Some developers never commit derived files, files that can be generated automatically. For an R package this would mean ignoring the files `NAMESPACE` and anything in the `man/` directory because they're generated from comments. From a practical pespective, it's better to commit these files: R packages have no way to generate `.Rd` files on installation so ignoring derived files means that users who install your package from GitHub will have no documentation.
 
 ## Undo a mistake {#git-undo}
 


### PR DESCRIPTION
Currently it reads like `NAMESPACE` is a directory. Alternative:

> the `NAMESPACE` file and files in the `man/` directory