### PR TITLE
Deleted context() recommendation

### DIFF
--- a/testing.Rmd
+++ b/testing.Rmd
@@ -393,7 +393,7 @@ test_that("floor_date works for different units", {
 
 ## Test files {#test-files}
 
-The highest-level structure of tests is the file. Each file should contain a single `context()` call that provides a brief description of its contents. Just like the files in the `R/` directory, you are free to organise your tests any way that you like. But again, the two extremes are clearly bad (all tests in one file, one file per test). You need to find a happy medium that works for you. A good starting place is to have one file of tests for each complicated function.
+The highest-level structure of tests is the file. Just like the files in the `R/` directory, you are free to organise your tests any way that you like. But again, the two extremes are clearly bad (all tests in one file, one file per test). You need to find a happy medium that works for you. A good starting place is to have one file of tests for each complicated function.
 
 ## CRAN notes {#test-cran}
 


### PR DESCRIPTION
I believe it's not longer recommended to use `context()`. It is mentioned elsewhere in the chapter but I believe It'd better be adapted by the author