### PR TITLE
Fix link in Introduction.Rmd

### DIFF
--- a/Introduction.Rmd
+++ b/Introduction.Rmd
@@ -54,7 +54,7 @@ Chapter \@ref(whole-game) runs through the development of a small toy package. I
 
 Chapter \@ref(setup) describes how to prepare your system for package development, which has more requirements than simply running R scripts. This includes recommendations on some optional setup that can make your workflow more pleasant, which tends to lead to a higher-quality product.
 
-The basic structure of a package and how that varies across different states is explained in chapter \@ref(package-structure).
+The basic structure of a package and how that varies across different states is explained in chapter \@ref(package-structure-state).
 
 Chapter \@ref(workflows101) goes over core workflows that come up repeatedly for package developers. This chapter also covers connections between our favored tools, such as devtools/usethis and RStudio, and the philosophies that drive the design of these tools.
 


### PR DESCRIPTION
It seems to me that the link in the third paragraph of section 1.2 at https://r-pkgs.org/intro.html should not point to chapter 17.2.2 but to chapter 4. I'm not very experience with RMarkdown so I don't know whether I changed the document correctly. I also don't know how to build this book in order to test it.

I assign the copyright of this contribution to Hadley Wickham.