### PR TITLE
Remove full stop in examples' title

### DIFF
--- a/man.Rmd
+++ b/man.Rmd
@@ -38,7 +38,7 @@ In this section, we'll first go over a rough outline of the complete documentati
 The process starts when you add roxygen comments to your source file: roxygen comments start with `#'` to distinguish them from regular comments. Here's documentation for a simple function:
 
 ```{r}
-#' Add together two numbers.
+#' Add together two numbers
 #' 
 #' @param x A number.
 #' @param y A number.
@@ -136,7 +136,7 @@ All objects must have a title and description. Details are optional.
 Here's an example showing what the introduction for `sum()` might look like if it had been written with roxygen:
 
 ```{r}
-#' Sum of vector elements.
+#' Sum of vector elements
 #' 
 #' \code{sum} returns the sum of all the values present in its arguments.
 #' 
@@ -231,7 +231,7 @@ Functions are the most commonly documented object. As well as the introduction b
 We could use these new tags to improve our documentation of `sum()` as follows:
 
 ```{r}
-#' Sum of vector elements.
+#' Sum of vector elements
 #'
 #' \code{sum} returns the sum of all the values present in its arguments.
 #'
@@ -278,7 +278,7 @@ You can use roxygen to provide a help page for your package as a whole. This is 
 There's no object that corresponds to a package, so you need to document `NULL`, and then manually label it with `@docType package` and `@name <package-name>`. This is also an excellent place to use the `@section` tag to divide up page into useful categories.
 
 ```{r}
-#' foo: A package for computating the notorious bar statistic.
+#' foo: A package for computating the notorious bar statistic
 #'
 #' The foo package provides three categories of important functions:
 #' foo, bar and baz.


### PR DESCRIPTION
Following the "suggestion" as in:

> * The first _sentence_ becomes the title of the documentation. That's what you 
>  see when you look at `help(package = mypackage)` and is shown at the top of 
>  each help file. It should fit on one line, be written in sentence case, but not 
>  end in a full stop.

I removed the full stop from the examples in this chapter.

Not sure about S4 and RC so I haven't touched those.