### PR TITLE
Fix URL for R-devel for Mac

### DIFF
--- a/release.Rmd
+++ b/release.Rmd
@@ -204,7 +204,7 @@ These are described in more detail below.
 
 When checking your package you need to make sure that it passed with the current development version of R and it works on at least two platforms. `R CMD check` is continuously evolving, so it's a good idea to check your package with the latest development version, __R-devel__. You can install R-devel on your own machine:
 
-* Mac: install from <http://r.research.att.com>.
+* Mac: install from <https://mac.r-project.org/>.
 
 * Windows: install from <http://cran.r-project.org/bin/windows/base/rdevel.html>
 


### PR DESCRIPTION
Moved from the old att.com location (though it still redirects okay). "This is the new home for experimental binaries and documentation related to R for macOS." Neighboring links look okay.

Copyright requirements sound good to me&mdash;I assign the copyright of this contribution to Hadley Wickham.