### PR TITLE
Fix a reference label conflict.

### DIFF
--- a/data.Rmd
+++ b/data.Rmd
@@ -1,4 +1,4 @@
-# External data {#data-chapter}
+# External data {#data}
 
 ```{r, include = FALSE}
 source("common.R")

--- a/data.Rmd
+++ b/data.Rmd
@@ -1,4 +1,4 @@
-# External data {#data}
+# External data {#data-chapter}
 
 ```{r, include = FALSE}
 source("common.R")

--- a/license.Rmd
+++ b/license.Rmd
@@ -128,7 +128,7 @@ If you do need to re-license a package, we recommend the following steps:
 [^license-1]: Very simple contributions like typo fixes are generally not protected by copyright because they're not creative works.
     But even a single sentence can be considered a creative work, so err on the side of safety, and if you have any doubts leave the contributor in.
 
-### Data
+### Data {#license-data}
 
 Open source licenses are designed specifically to apply to source code, so if you're releasing a package that primarily contains data, you should use a different type of license.
 We recommend one of two [Creative Commons](http://creativecommons.org/) licenses:


### PR DESCRIPTION
The original reference label for chapter `External data` is `#data`. But there is also a subsection called `Data`(without manually given reference label) in chapter `License`. This means  the rendered book will have the hyperlink of `External data` pointing to this subsection in `License`. Therefore, I have changed the label of `External data` to `#data-chapter`.