### PR TITLE
add a note on usethis package for testing

### DIFF
--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -46,6 +46,7 @@ Load the devtools package, which is the public face of a set of packages that su
 
 ```{r}
 library(devtools)
+library(usethis)
 ```
 
 Do you have an old version of devtools? Compare your version against ours and upgrade if necessary.
@@ -543,10 +544,10 @@ Success!
 
 We've tested `fbind()` informally, in a single example. We can formalize and expand this with some unit tests. This means we express a few concrete expectations about the correct `fbind()` result for various inputs.
 
-First, we declare our intent to write unit tests and to use the testthat package for this, via `use_testthat()`:
+First, we declare our intent to write unit tests and to use the `usethis` package for this, via `use_testthat()`:
 
 ```{r use-testthat, eval = create}
-use_testthat()
+usethis::use_testthat()
 ```
 
 This initializes the unit testing machinery for your package. It adds `Suggests: testthat` to `DESCRIPTION`, creates the directory `tests/testthat/`, and adds the script `test/testthat.R`.


### PR DESCRIPTION
The documentation previously suggests `use_testthat()` function is part of `testthat`. However, it is part of `usethis`