### PR TITLE
Add missing anchors/refs to license chapter

### DIFF
--- a/license.Rmd
+++ b/license.Rmd
@@ -130,7 +130,7 @@ There are three key files used to record your licensing decision:
 -   `LICENSE.md` includes a copy of the full text of the license.
     All open source licenses require a copy of the license to be included, but CRAN does not permit you to include a copy of standard licenses in your package, so we also use `.Rbuildignore` to make sure this file is not sent to CRAN.
 
-There is one other file that we'll come back to in Section \@ref(code-you-borrow): `LICENSE.note`.
+There is one other file that we'll come back to in Section \@ref(how-to-include): `LICENSE.note`.
 This is used when you have bundled code written by other people, and parts of your package have more permissive licenses than the whole.
 
 ### More licenses {#more-licenses}
@@ -257,7 +257,7 @@ If your package isn't open source, things are more complicated.
 Permissive licenses are still easy, and copyleft licenses generally don't restrict use as long as you don't distribute the package outside your company.
 But this is a complex issue and opinions differ, and should check with your legal department first.
 
-### How to include
+### How to include {#how-to-include}
 
 Once you've determined that the licenses are compatible, you can bring the code in your package.
 When doing so, you need to preserve all existing license and copyright statements, and make it as easy as possible for future readers to understanding the licensing situation:

--- a/license.Rmd
+++ b/license.Rmd
@@ -159,7 +159,7 @@ The primary downside of choosing a license not in the bullet list above is that 
 ### Relicensing
 
 It's important to spend a little time thinking about your initial license because it can be hard to change it later because it requires the permission of all copyright holders.
-Unless you've done something special (which we'll discuss in Section \@ref(code-you-receive)), the copyright holders include everyone who has contributed a non-trivial amount of code.
+Unless you've done something special (which we'll discuss in Section \@ref(code-given-to-you)), the copyright holders include everyone who has contributed a non-trivial amount of code.
 
 If you do need to re-license a package, we recommend the following steps:
 
@@ -188,7 +188,7 @@ We recommend one of two [Creative Commons](http://creativecommons.org/) licenses
 
 -   If you want to require attribution when someone else uses your data, you can use the CC-BY license, with `use_ccby_license()`.
 
-## Code given to you
+## Code given to you {#code-given-to-you}
 
 Many packages include code not written by the author.
 There are two main ways this happens: other people might choose to contribute to your package using a pull request or similar, or you might find some code and choose to bundle it.


### PR DESCRIPTION
The license chapter currently has two internal links that are broken (you can find them by searching for "??" in the [book](https://r-pkgs.org/license.html)). The commits in this PR create the heading anchors and fix the refs for both.

I assign the copyright of this contribution to Hadley Wickham.