### PR TITLE
Add comment about `LazyDataCompression`

### DIFF
--- a/data.Rmd
+++ b/data.Rmd
@@ -143,3 +143,6 @@ Generally, package data should be smaller than a megabyte - if it's larger you'l
    If you've lost the code for recreating the files, you can use 
    `tools::resaveRdaFiles()` to re-save in place.
 
+3. Add the field `LazyDataCompression` to the `DESCRIPTION` file with the optimal
+   compression method, e.g. `LazyDataCompression: xz`.
+


### PR DESCRIPTION
Using a compression method that is not `gzip`, then this should also be specified in the corresponding DESCRIPTION field `LazyDataCompression`, because otherwise the default value `gzip` is used in the installed lazy-loading database. 

Unlike `sysdata.rda`, `xz` is not automatically used for larger exported data, so one should explicitly specify the method.

See 'Writing R Extensions' §1.1.6