### PR TITLE
Suggest alternative error handling functions

### DIFF
--- a/src.Rmd
+++ b/src.Rmd
@@ -399,7 +399,7 @@ Using C code from another package varies based on how the package is implemented
 ### Best practices {#c-best-practices}
 
 * Avoid calls to `assert()`, `abort()` and `exit()`: these will kill the 
-  R process, not just your C code. Instead, use `error()` which is 
+  R process, not just your C code. Instead, use `Rcpp::stop()` or `Rf_error()` which are 
   equivalent to calling `stop()` in R.
 
 * To print output use `Rprintf()`, not `printf()`. Doing so always prints to 


### PR DESCRIPTION
There is no `error` function in `Rcpp`. Probably either `Rcpp::stop()` or `Rf_error()` are accepted by CRAN though?