### PR TITLE
Fix a mistake on a variable name of R code example

### DIFF
--- a/Package-within.Rmd
+++ b/Package-within.Rmd
@@ -419,7 +419,7 @@ f_to_c <- function(x) (x - 32) * 5/9
 
 #' @export
 celsify_temp <- function(dat) {
-  dplyr::mutate(dat, temp = dplyr::if_else(where == "US", f_to_c(temp), temp))
+  dplyr::mutate(dat, temp = dplyr::if_else(english == "US", f_to_c(temp), temp))
 }
 
 now <- Sys.time()


### PR DESCRIPTION
### Fix a mistake on variable name use in a code snippet
IN R CMD CHECK there is a passage of CHECK complaining about `english` but it was not being used in the code.

I assign the copyright of this contribution to Hadley Wickham