### PR TITLE
Fixed a typo.

### DIFF
--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -585,7 +585,7 @@ cat(test_fodder, sep = "\n")
 ```
 :::
 
-This tests that `fbind()` gives an expected result when combining two factors and a character vector and a factor.
+This tests that `fbind()` gives an expected result when combining two character vectors and a character vector and a factor.
 
 ```{r commit-fbind-test, echo = debug, comment = NA, eval = FALSE}
 git_add(path("tests", "testthat", "test-fbind.R"))


### PR DESCRIPTION
Made the following change:

> This tests that fbind() gives an expected result when combining two ~factors~ character vectors and a character vector and a factor.

`x` and `y` are character vectors, not factors.