### PR TITLE
Update metadata.R to use given/family in person()

### DIFF
--- a/metadata.Rmd
+++ b/metadata.Rmd
@@ -12,7 +12,7 @@ Every package must have a `DESCRIPTION`. In fact, it's the defining feature of a
 Package: mypackage
 Title: What The Package Does (one line, title case required)
 Version: 0.1
-Authors@R: person("First", "Last", email = "first.last@example.com",
+Authors@R: person("Given", "Family", email = "given.family@example.com",
                   role = c("aut", "cre"))
 Description: What the package does (one paragraph)
 Depends: R (>= 3.1.0)


### PR DESCRIPTION
`first` and `last` are depreciated in favour of `given` and `family` in `person()`. This minor change updates to be in line with that.

"I assign the copyright of this contribution to Hadley Wickham" - James McMahon 14 September 2021