### PR TITLE
Also use the css for bs4_book

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -1,4 +1,5 @@
 bookdown::bs4_book:
+  css: style.css
   theme:
     primary: "#982a31"
     fg: "#2b2121"

--- a/style.css
+++ b/style.css
@@ -1,20 +1,3 @@
-p.caption {
-  color: #777;
-  margin-top: 10px;
-}
-p code {
-  white-space: inherit;
-}
-pre {
-  word-break: normal;
-  word-wrap: normal;
-}
-pre code {
-  white-space: inherit;
-}
-
-/* Sidebar formating --------------------------------------------*/
-
 div.rstudio-tip, div.tip {
   border: 4px solid #ddd;
   border-radius: 5px;


### PR DESCRIPTION
@Hadley I did this because the switch to `bs4_book()` meant that our special "tips" (for RStudio, a general tip) were no longer being formatted specially.

But now that I look harder at `style.css`, I'm not sure this is really quite the right or complete solution. Should we split the tip stuff out? I also have no idea why some of the tip stuff is under a comment that says `Sidebar formating`. And I see some duplication in the file too. Basically it feels a bit crufty. Thoughts?