### PR TITLE
Add `r ''` to the chunk header instead of inserting a zero-width space

### DIFF
--- a/vignettes.Rmd
+++ b/vignettes.Rmd
@@ -236,7 +236,7 @@ Knitr allows you to intermingle code, results and text. Knitr takes R code, runs
 
 Consider the simple example below. Note that a knitr block looks similar to a fenced code block, but instead of using `r`, you are using `{r}`.
 
-    `​``{r}
+    ```{r}`r ''`
     # Add two numbers together
     add <- function(a, b) a + b
     add(10, 20)


### PR DESCRIPTION
Doc: https://bookdown.org/yihui/rmarkdown-cookbook/verbatim-code-chunks.html

This fixes the warning that @jennybc asked about:

```
Warning message:
In xfun::prose_index(x) : Code fences are not balanced
```

Hopefully in the next version of knitr, it will be less hacky to write verbatim code chunks.