### PR TITLE
Prefer `.rda` over `.RData` ext for exported data

### DIFF
--- a/data.Rmd
+++ b/data.Rmd
@@ -23,14 +23,14 @@ Each possible location is described in more detail below.
 
 ## Exported data {#data-data}
 
-The most common location for package data is (surprise!) `data/`. Each file in this directory should be a `.RData` file created by `save()` containing a single object (with the same name as the file). The easiest way to adhere to these rules is to use `usethis::use_data()`:
+The most common location for package data is (surprise!) `data/`. Each file in this directory should be an `.rda` (or `.RData`) file created by `save()` containing a single object (with the same name as the file). The easiest way to adhere to these rules is to use `usethis::use_data()`:
 
 ```{r, eval = FALSE}
 x <- sample(1000)
 usethis::use_data(x, mtcars)
 ```
 
-It's possible to use other types of files, but I don't recommend it because `.RData` files are already fast, small and explicit. Other options are described in `data()`. For larger datasets, you may want to experiment with the compression setting. The default is `bzip2`, but sometimes `gzip` or `xz` can create smaller files.
+It's possible to use other types of files, but I don't recommend it because `.rda` files are already fast, small and explicit. Other options are described in `data()`. For larger datasets, you may want to experiment with the compression setting. The default is `bzip2`, but sometimes `gzip` or `xz` can create smaller files.
 
 If the `DESCRIPTION` contains `LazyData: true`, then datasets will be lazily loaded. This means that they won't occupy any memory until you use them. The following example shows memory usage before and after loading the nycflights13 package. You can see that memory usage doesn't change until you inspect the flights dataset stored inside the package. 
 


### PR DESCRIPTION
`usethis::use_data(..., internal = FALSE)` creates `.rda` files, so this is more consistent.