### PR TITLE
`expect_is()` is superseded, new options added

### DIFF
--- a/testing.Rmd
+++ b/testing.Rmd
@@ -225,7 +225,9 @@ While you'll normally put expectations inside tests inside files, you can also r
     expect_error(1 / 2) 
     ```
 
-*   `expect_is()` checks that an object `inherit()`s from a specified class.
+*   `expect_is()` checks that an object `inherit()`s from a specified class
+    (superseded, `expect_type()`, `expect_s3_class()` or `expect_s4_class()`
+    are now the suggested functions).
 
     ```{r, error = TRUE, eval = FALSE}
     model <- lm(mpg ~ wt, data = mtcars)


### PR DESCRIPTION
As mentioned [here](https://rdrr.io/cran/testthat/man/expect_is.html), the new [inheritance-expectations](https://rdrr.io/cran/testthat/man/inheritance-expectations.html) should be used instead of `expect_is()`.