### PR TITLE
explicit call to package because no packages loaded in new session

### DIFF
--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -208,6 +208,12 @@ A select few are visible all the time, but sometimes you want to see them all.
   Even if you don't use RStudio, this file is harmless.
   Or you can suppress its creation with `create_package(..., rstudio = FALSE)`.
   More in \@ref(projects).
+  
+You probably need to call `library(devtools)` again, because `create_package()` has probably dropped you into a fresh R session, in your new package.
+
+```{r eval = FALSE}
+library(devtools)
+```
 
 ## `use_git()`
 
@@ -220,7 +226,6 @@ The regexcite directory is an R source package and an RStudio Project.
 Now we make it also a Git repository, with `use_git()`.
 
 ```{r use-git, eval = create}
-library(devtools)
 use_git()
 ```
 

--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -220,7 +220,7 @@ The regexcite directory is an R source package and an RStudio Project.
 Now we make it also a Git repository, with `use_git()`.
 
 ```{r use-git, eval = create}
-use_git()
+devtools::use_git()
 ```
 
 In an interactive session, you will be asked if you want to commit some files here and you should probably accept the offer.

--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -220,7 +220,8 @@ The regexcite directory is an R source package and an RStudio Project.
 Now we make it also a Git repository, with `use_git()`.
 
 ```{r use-git, eval = create}
-devtools::use_git()
+library(devtools)
+use_git()
 ```
 
 In an interactive session, you will be asked if you want to commit some files here and you should probably accept the offer.


### PR DESCRIPTION
The previous step, `create_package`, opens a new session. No packages are loaded in this new session, so calling `use_git()` fails. I propose either referencing the package via `usethis::use_git()`, or, more robustly (for later calls), to include `library(devtools)` and a brief explanation.