### PR TITLE
tweak rstudio + git wording

### DIFF
--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -268,6 +268,7 @@ git_log(max = 1) %>%
 RStudio can initialize a Git repository, in any Project, even if it's not an R package, as long you've set up RStudio + Git integration.
 Do *Tools > Version Control > Project Setup*.
 Then choose *Version control system: Git* and *initialize a new git repository for this project*.
+`use_git()` also works in non-package RStudio Projects.
 :::
 
 ## Write the first function


### PR DESCRIPTION
this sort of sounds like `use_git()` won't work in a non-package project