### PR TITLE
refer to @export as tag

### DIFF
--- a/Whole-game.Rmd
+++ b/Whole-game.Rmd
@@ -605,7 +605,7 @@ This polishes off niceties like the links between help files and the creation of
 
 ### `NAMESPACE` changes
 
-In addition to converting `strsplit1()`'s special comment into `man/strsplit1.Rd`, the call to `document()` updates the `NAMESPACE` file, based on `@export` directives found in roxygen comments.
+In addition to converting `strsplit1()`'s special comment into `man/strsplit1.Rd`, the call to `document()` updates the `NAMESPACE` file, based on `@export` tags found in roxygen comments.
 Open `NAMESPACE` for inspection.
 The contents should be:
 


### PR DESCRIPTION
instead of a directive, because it's confusing to call it that for the tag and the namespace call and more consistent with roxygen terminology