### PR TITLE
Lines 454 and 456: Typos

### DIFF
--- a/testing-design.Rmd
+++ b/testing-design.Rmd
@@ -451,9 +451,9 @@ It might make sense to gather such helpers in a clearly marked file, such as one
         ├── utils-testing.R
         └── ...
 
-### `tests/testhat.R`
+### `tests/testthat.R`
 
-Recall the initial testthat setup described in @sec-tests-mechanics-workflow: The standard `tests/testhat.R` file looks like this:
+Recall the initial testthat setup described in @sec-tests-mechanics-workflow: The standard `tests/testthat.R` file looks like this:
 
 ```{r eval = FALSE}
 library(testthat)


### PR DESCRIPTION
'testhat.R's should be changed to 'testthat.R'.