### PR TITLE
Grammar fix (16.2.1)

### DIFF
--- a/man.Rmd
+++ b/man.Rmd
@@ -100,7 +100,7 @@ To summarize, there are four steps in the basic roxygen2 workflow:
 
 1.  Add roxygen2 comments to your `.R` files.
 
-2.  Run press Ctrl/Cmd + Shift + D or `devtools::document()` to convert roxygen comments to `.Rd` files.
+2.  Press Ctrl/Cmd + Shift + D or run `devtools::document()` to convert roxygen comments to `.Rd` files.
 
 3.  Preview documentation with `?`.
 


### PR DESCRIPTION
You can't "run press" a key combo and a command; you press a key combo and run a command.