### PR TITLE
Typo and wrong body of a function

### DIFF
--- a/testing-advanced.Rmd
+++ b/testing-advanced.Rmd
@@ -128,12 +128,12 @@ Here's a sketch of how this could look:
 
 ```{r eval = FALSE}
 test_that("foofy() does this", {
-  useful_thing1 <- readRDS(test_path("fixtures", "useful_thing.rds"))
+  useful_thing1 <- readRDS(test_path("fixtures", "useful_thing1.rds"))
   expect_equal(foofy(useful_thing1, x = "this"), EXPECTED_FOOFY_OUTPUT)
 })
 
 test_that("foofy() does that", {
-  useful_thing2 <- readRDS(test_path("fixtures", "useful_thing.rds"))
+  useful_thing2 <- readRDS(test_path("fixtures", "useful_thing2.rds"))
   expect_equal(foofy(useful_thing2, x = "that"), EXPECTED_FOOFY_OUTPUT)
 })
 ```

--- a/testing-advanced.Rmd
+++ b/testing-advanced.Rmd
@@ -250,7 +250,7 @@ Finally, it can be handy to know that testthat makes specific information availa
 
     ```{r, eval = FALSE}
     is_testing <- function() {
-      Sys.getenv("TESTTHAT_PKG")
+      identical(Sys.getenv("TESTTHAT"), "true")
     }
     ```
 


### PR DESCRIPTION
1. On the file listing there are 2 files: `useful_thing1.rds` and `useful_thing2.rds`, but the code wrongly referenced to `useful_thing.rds`.
2. Function `is_testing()` is different from `testing_package()`.