### PR TITLE
Fix typo

### DIFF
--- a/testing-advanced.Rmd
+++ b/testing-advanced.Rmd
@@ -250,7 +250,7 @@ Finally, it can be handy to know that testthat makes specific information availa
 
     ```{r, eval = FALSE}
     is_testing <- function() {
-      Sys.getenv("TESTTHAT_PKG")
+      Sys.getenv("TESTTHAT")
     }
     ```
 


### PR DESCRIPTION
`is_testing()` is a shortcut for variable `TESTTHAT`