### PR TITLE
Typos for testing chapters

### DIFF
--- a/testing-advanced.Rmd
+++ b/testing-advanced.Rmd
@@ -128,12 +128,12 @@ Here's a sketch of how this could look:
 
 ```{r eval = FALSE}
 test_that("foofy() does this", {
-  useful_thing1 <- readRDS(test_path("fixtures", "useful_thing.rds"))
+  useful_thing1 <- readRDS(test_path("fixtures", "useful_thing1.rds"))
   expect_equal(foofy(useful_thing1, x = "this"), EXPECTED_FOOFY_OUTPUT)
 })
 
 test_that("foofy() does that", {
-  useful_thing2 <- readRDS(test_path("fixtures", "useful_thing.rds"))
+  useful_thing2 <- readRDS(test_path("fixtures", "useful_thing2.rds"))
   expect_equal(foofy(useful_thing2, x = "that"), EXPECTED_FOOFY_OUTPUT)
 })
 ```
@@ -154,7 +154,7 @@ Now we can revisit a file listing from earlier, which addressed exactly this sce
         └── testthat.R
 
 This shows static test files stored in `tests/testthat/fixtures/`, but also notice the companion R script, `make-useful-things.R`.
-From data analysis, we all know there is no such things as a script that is run only once.
+From data analysis, we all know there is no such thing as a script that is run only once.
 Refinement and iteration is inevitable.
 This also holds true for test objects like `useful_thing1.rds`.
 We highly recommend saving the R code used to create your test objects, so that they can be re-created as needed.
@@ -216,7 +216,7 @@ Above, it's very easy to watch the result change as we truncate the input from t
 Note that this technique should be used in extreme moderation.
 A helper like `trunc()` is yet another place where you can introduce a bug, so it's best to keep such helpers extremely short and simple.
 
-### Custom expectatations
+### Custom expectations
 
 If a more complicated helper feels necessary, it's a good time to reflect on why that is.
 If it's fussy to get into position to *test* a function, that could be a sign that it's also fussy to *use* that function.

--- a/testing-design.Rmd
+++ b/testing-design.Rmd
@@ -40,7 +40,7 @@ It's hard to give good general advice about writing tests, but you might find th
 ### Test coverage
 
 Another concrete way to direct your test writing efforts is to examine your test coverage.
-The covr package (\<<https://covr.r-lib.org>) can be used to determine which lines of your package's source code are (or are not!) executed when the test suite is run.
+The covr package (<https://covr.r-lib.org>) can be used to determine which lines of your package's source code are (or are not!) executed when the test suite is run.
 This is most often presented as a percentage.
 Generally speaking, the higher the better.
 
@@ -96,7 +96,7 @@ Recall this advice found in @sec-code-r-landscape, which covers your package's "
 We have analogous advice for your test files:
 
 > The `test-*.R` files below `tests/testthat/` should consist almost entirely of calls to `test_that()`.
-> Any other top-level code is suspicious and should be carefully considered for relocation into calls to `test_that()` or to other files that get special treatment inside an R package or from the testthat.
+> Any other top-level code is suspicious and should be carefully considered for relocation into calls to `test_that()` or to other files that get special treatment inside an R package or from testthat.
 
 Eliminating (or at least minimizing) top-level code outside of `test_that()` will have the beneficial effect of making your tests more hermetic.
 This is basically the testing analogue of the general programming advice that it's wise to avoid unstructured sharing of state.


### PR DESCRIPTION
just minor things like typos and one instance where I think the code example for test fixures got out of sync with the corresponding file structure