### PR TITLE
Change license sticky versioning example from = to ==

### DIFF
--- a/license.Rmd
+++ b/license.Rmd
@@ -111,7 +111,7 @@ There are three key files used to record your licensing decision:
     It comes in four main forms:
 
     -   A name and version specification, e.g.
-        `GPL (>= 2)`, or `Apache License (= 2.0)`.
+        `GPL (>= 2)`, or `Apache License (== 2.0)`.
 
     -   A standard abbreviation, e.g.
         `GPL-2`, `LGPL-2.1`, `Artistic-2.0`.


### PR DESCRIPTION
Missing one = in the example Apache license. 