### PR TITLE
Fix plaintext typos

### DIFF
--- a/Introduction.Rmd
+++ b/Introduction.Rmd
@@ -58,7 +58,7 @@ We try to develop practices that make life more enjoyable for both the maintaine
 The devtools meta-package is where these lessons are made concrete.
 
 devtools works hand-in-hand with RStudio, which we believe is the best development environment for most R users.
-The main alternative is [Emacs Speaks Statistics](http://ess.r-project.org/) (ESS), which is a rewarding environment if you're willing to put in the time to learn Emacs and customise it to your needs.
+The main alternative is [Emacs Speaks Statistics](https://ess.r-project.org/) (ESS), which is a rewarding environment if you're willing to put in the time to learn Emacs and customise it to your needs.
 The history of ESS stretches back over 20 years (predating R!), but it's still actively developed and many of the workflows described in this book are also available there.
 For those loyal to vim, we recommend the [Nvim-R plugin](https://github.com/jalvesaq/Nvim-R).
 
@@ -124,7 +124,7 @@ There are a few very important topics that you won't learn about in this book:
 <!-- TODO: complete these comments -->
 
 -   Git and GitHub: mastering a version control system is vital to easily collaborate with others, and is useful even for solo work because it allows you to easily undo mistakes.
-    Learn from <http://happygitwithr.com/>.
+    Learn from <https://happygitwithr.com/>.
 
 -   Compiled code: R code is designed for human efficiency, not computer efficiency, so it's useful to have a tool in your back pocket that allows you to write fast code.
     Learn more in <https://adv-r.hadley.nz/rcpp.html>, or <https://cpp11.r-lib.org>.
@@ -217,7 +217,7 @@ Output comments look like `#>` to distinguish them from regular comments.
 
 ## Colophon {#intro-colophon}
 
-This book was authored using [quarto](https://quarto.org) inside [RStudio](https://www.rstudio.com/products/rstudio/).
+This book was authored using [Quarto](https://quarto.org) inside [RStudio](https://www.rstudio.com/products/rstudio/).
 The [website](https://r-pkgs.org) is hosted with [Netlify](https://www.netlify.com), and automatically updated after every commit by GitHub actions.
 The complete source is available from [GitHub](https://github.com/hadley/r-pkgs).
 


### PR DESCRIPTION
I fixed one capitalization typo in plaintext and converted two `http` links to `https`.