### PR TITLE
Remove "ggplot2 should `Depend` on scales"

### DIFF
--- a/dependencies.Rmd
+++ b/dependencies.Rmd
@@ -559,7 +559,6 @@ That's because a good package is self-contained, and minimises changes to the gl
 The only exception is if your package is designed to be used in conjunction with another package.
 For example, the [analogue](https://github.com/gavinsimpson/analogue) package builds on top of [vegan](https://github.com/vegandevs/vegan).
 It's not useful without vegan, so it has vegan in `Depends` instead of `Imports`.
-Similarly, ggplot2 should really `Depend` on scales, rather than `Import`ing it.
 
 Now that you understand the importance of the namespace, let's dive into the nitty gritty details.
 The two sides of the package namespace, imports and exports, are both described by the `NAMESPACE`.


### PR DESCRIPTION
I stumbled over this sentence and I think it should go. 

1. ggplot2 does not depend on scales anymore (if it ever did)
2. from my reading of #485 and [leeper/Depends](https://github.com/leeper/Depends) the sentence is not what you'd advice now (I assume)
3. avoid others tripping over this until this section is up for editing