### PR TITLE
Fix missing newline in R-CMD-check docs

### DIFF
--- a/R-CMD-check.Rmd
+++ b/R-CMD-check.Rmd
@@ -446,7 +446,9 @@ If you have documentation problems, it's best to iterate quickly with `check_man
  tools:::check_compiled_code
  -->
 ```
--   **Checking compiled code**. Checks that you're not using any C functions that you shouldn't. \### Tests {#tests}
+-   **Checking compiled code**. Checks that you're not using any C functions that you shouldn't.
+   
+## Tests {#tests}
 
 <!-- https://github.com/wch/r-source/blob/trunk/src/library/tools/R/check.R#L2514 -->
 


### PR DESCRIPTION
[R-CMD-check docs](https://r-pkgs.org/R-CMD-check.html#compiled-code:~:text=Checking%20compiled%20code.%20Checks%20that%20you%E2%80%99re%20not%20using%20any%20C%20functions%20that%20you%20shouldn%E2%80%99t.%20%23%23%23%20Tests%20%7B%23tests%7D) have a tests section without a newline so it is rendered as raw markdown.

<img width="776" alt="image" src="https://user-images.githubusercontent.com/1639487/210431541-700866ef-6b71-4f2e-ac44-2e0933b7cbf1.png">

I assign the copyright of this contribution to Hadley Wickham