### PR TITLE
remove spacing between highlighting comments and code

### DIFF
--- a/testing-design.Rmd
+++ b/testing-design.Rmd
@@ -214,7 +214,7 @@ You've already seen an example of its usage, when we explored snapshot tests:
 
 ```{r eval = FALSE}
 test_that("side-by-side diffs work", {
-  withr::local_options(width = 20)             # <-- (°_°) look here!
+  withr::local_options(width = 20) # <-- (°_°) look here!
   expect_snapshot(
     waldo::compare(c("X", letters), c(letters, "X"))
   )
@@ -269,7 +269,7 @@ In testthat 3e, `testthat::local_reproducible_output()` is implicitly part of ea
 
 ```{r, eval = FALSE}
 test_that("something specific happens", {
-  local_reproducible_output()     # <-- this happens implicitly
+  local_reproducible_output() # <-- this happens implicitly
   
   # your test code, which might be sensitive to ambient conditions, such as
   # display width or the number of supported colors


### PR DESCRIPTION
on narrow screens, the `# <-- look here` style inline comments are often hidden in the overflow.