### PR TITLE
Dependencies: change internal link branch name

### DIFF
--- a/dependencies-in-practice.Rmd
+++ b/dependencies-in-practice.Rmd
@@ -511,7 +511,7 @@ https://github.com/wch/r-source/blob/efacf56dcf2f880b9db8eafa28d49a08d56e861e/sr
 ```
 The use of `Config/Needs/*` is not directly related to devtools.
 It's more accurate to say that it's associated with continuous integration workflows made available to the community at <https://github.com/r-lib/actions/> and exposed via functions such as `usethis::use_github_actions()`.
-A `Config/Needs/*` field tells the [`setup-r-dependencies`](https://github.com/r-lib/actions/tree/master/setup-r-dependencies#readme) GitHub Action about extra packages that need to be installed.
+A `Config/Needs/*` field tells the [`setup-r-dependencies`](https://github.com/r-lib/actions/tree/HEAD/setup-r-dependencies#readme) GitHub Action about extra packages that need to be installed.
 
 `Config/Needs/website` is the most common and it provides a place to specify packages that aren't a formal dependency, but that must be present in order to build the package's website (@sec-website).
 The readxl package is a good example.


### PR DESCRIPTION
There was a link that went to the `master` branch of the actions repository. I've changed it to be `HEAD` so that it redirects to the right place.