### PR TITLE
Format tables in whole-game with kable

### DIFF
--- a/whole-game.Rmd
+++ b/whole-game.Rmd
@@ -177,7 +177,8 @@ Here's a listing (locally, you can consult your *Files* pane):
 
 ```{r init-show-files, echo = FALSE, eval = create}
 dir_info(all = TRUE) %>% 
-  select(path, type)
+  select(path, type) %>%
+  knitr::kable()
 ```
 
 ::: callout-tip
@@ -226,7 +227,8 @@ Its existence is evidence that we have indeed initialized a Git repo here.
 
 ```{r post-git-file-list, echo = FALSE, eval = create}
 dir_info(all = TRUE, regexp = "^[.]git$") %>% 
-  select(path, type)
+  select(path, type) %>%
+  knitr::kable()
 ```
 
 If you're using RStudio, it probably requested permission to relaunch itself in this Project, which you should do.
@@ -239,7 +241,9 @@ Click on History (the clock icon in the Git pane) and, if you consented, you wil
 
 ```{r inspect-first-commit, echo = FALSE, eval = create}
 git_log(max = 1) %>% 
-  select(commit, author, message)
+  select(commit, author, message) %>%
+  mutate(commit = paste0(substr(commit, 1, 10), "...")) %>%
+  knitr::kable()
 ```
 
 ::: callout-tip


### PR DESCRIPTION
As suggested in #790. I also truncated the commit hash in the git log table since it took up a lot of horizontal space.

Screenshot attached here so you don't have to render the book to preview it:

![image](https://user-images.githubusercontent.com/2816635/217307918-c9f8410a-211d-4110-9ffb-130127fa1f17.png)
