### PR TITLE
Update Linux content in System Setup & Structure and State

### DIFF
--- a/setup.Rmd
+++ b/setup.Rmd
@@ -134,7 +134,11 @@ This includes a very great deal that you do not need, but it offers the advantag
 ### Linux
 
 Make sure you've installed not only R, but also the R development tools.
-For example, on Ubuntu (and Debian) you need to install the `r-base-dev` package.
+For example, on Ubuntu (and Debian) you need to install the `r-base-dev` package with:
+
+    sudo apt install r-base-dev
+
+On Fedora and RedHat, the development tools (called `R-core-devel`) will be installed automatically when you install with R with `sudo dnf install R`.
 
 ## Verify system prep
 

--- a/structure.Rmd
+++ b/structure.Rmd
@@ -361,16 +361,17 @@ Above, the macOS system is used as a primary development machine and has many pa
 The core set of base and recommended packages that ship with R live in the system-level library and are the same on all operating systems.
 This separation appeals to many developers and makes it easy to, for example, clean out your add-on packages without disturbing your base R installation.
 
-[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
+[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
 
 If you're on macOS or Linux and only see one library, there is no urgent need to change anything.
 But next time you upgrade R, consider creating a user-level library.
 By default, R looks for a user library found at the path stored in the environment variable `R_LIBS_USER`, which itself defaults to `~/Library/R/m/x.y/library,` on macOS, and `~/R/m-library/x.y` on Linux (where `m` is a concise description of your CPU architecture, and `x.y` is the R version).
 You can see this path with `Sys.getenv("R_LIBS_USER")`.
 These directories do not exist by default, and the use of them must be enabled by creating the directory.
-When you install a new version of R, and prior to installing any add-on packages, use `dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE)` to set up a user library.
+When you install a new version of R, and prior to installing any add-on packages, use `dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE)` to create a user library in the default location.
 Now you will have the library setup seen above.
-Alternatively, you could setup a user library elsewhere and tell R about that by setting the `R_LIBS_USER` environment variable in the `.Renviron` in your `HOME` directory.
+Alternatively, you could set up a user library elsewhere and tell R about that by setting the `R_LIBS_USER` environment variable in `.Renviron`.
+The simplest way to edit your `.Renviron` file is with `usethis::edit_r_environ()`, which will create the file if it doesn't exist, and open it for editing.
 
 The filepaths for these libraries also make it clear they are associated with a specific version of R (4.2.x at the time of writing), which is also typical.
 This reflects and enforces the fact that you need to reinstall your add-on packages when you update R from, say, 4.1 to 4.2, which is a change in the **minor** version.

--- a/structure.Rmd
+++ b/structure.Rmd
@@ -361,7 +361,7 @@ Above, the macOS system is used as a primary development machine and has many pa
 The core set of base and recommended packages that ship with R live in the system-level library and are the same on all operating systems.
 This separation appeals to many developers and makes it easy to, for example, clean out your add-on packages without disturbing your base R installation.
 
-[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Managing-libraries) in *R Installation and Administration* and the R help files for `Startup` and `.libPaths()`.
+[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
 
 If you're on macOS or Linux and only see one library, there is no urgent need to change anything.
 But next time you upgrade R, consider creating a user-level library.

--- a/structure.Rmd
+++ b/structure.Rmd
@@ -355,20 +355,22 @@ In both cases we see two active libraries, consulted in this order:
 1.  A user library
 2.  A system-level or global library
 
-This setup is typical on Windows, but is something you usually need to opt into on macOS [^structure-3].
+This setup is typical on Windows, but is something you usually need to opt into on macOS and Linux[^structure-3].
 With this setup, add-on packages installed from CRAN (or elsewhere) or under local development are kept in the user library.
 Above, the macOS system is used as a primary development machine and has many packages here (\~1000), whereas the Windows system is only used occasionally and is much more spartan.
-The core set of base and recommended packages that ship with R live in the system-level library and are the same on macOS and Windows.
+The core set of base and recommended packages that ship with R live in the system-level library and are the same on all operating systems.
 This separation appeals to many developers and makes it easy to, for example, clean out your add-on packages without disturbing your base R installation.
 
-[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*.
+[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Managing-libraries) in *R Installation and Administration* and the R help files for `Startup` and `.libPaths()`.
 
-If you're on macOS and only see one library, there is no urgent need to change anything.
+If you're on macOS or Linux and only see one library, there is no urgent need to change anything.
 But next time you upgrade R, consider creating a user-level library.
-By default, R looks for a user library found at the path stored in the environment variable `R_LIBS_USER`, which itself defaults to `~/Library/R/m/x.y/library,` (where `m` is a concise description of your CPU architecture, and `x.y` is the R version).
+By default, R looks for a user library found at the path stored in the environment variable `R_LIBS_USER`, which itself defaults to `~/Library/R/m/x.y/library,` on macOS, and `~/R/m-library/x.y` on Linux (where `m` is a concise description of your CPU architecture, and `x.y` is the R version).
+You can see this path with `Sys.getenv("R_LIBS_USER")`.
+These directories do not exist by default, and the use of them must be enabled by creating the directory.
 When you install a new version of R, and prior to installing any add-on packages, use `dir.create(Sys.getenv("R_LIBS_USER"), recursive = TRUE)` to set up a user library.
 Now you will have the library setup seen above.
-Alternatively, you could setup a user library elsewhere and tell R about that by setting the `R_LIBS_USER` environment variable in `.Renviron`.
+Alternatively, you could setup a user library elsewhere and tell R about that by setting the `R_LIBS_USER` environment variable in the `.Renviron` in your `HOME` directory.
 
 The filepaths for these libraries also make it clear they are associated with a specific version of R (4.2.x at the time of writing), which is also typical.
 This reflects and enforces the fact that you need to reinstall your add-on packages when you update R from, say, 4.1 to 4.2, which is a change in the **minor** version.


### PR DESCRIPTION
Adds additional information for Linux in:
- setting up a user library (Package Structure and State). Closes #851
- more details on installing Linux toolchain (System Setup). Closes #937 

It's possible I went too far down the `.libPaths()` rabbit hole, so let me know if I should remove some of the more esoteric details.