### PR TITLE
Update software-development-practices.Rmd

### DIFF
--- a/software-development-practices.Rmd
+++ b/software-development-practices.Rmd
@@ -144,7 +144,7 @@ Here's what that menu looks like at the time of writing:
 
 ```{r}
 #| eval: false
-> use_github_action()
+> use_github_actions()
 Which action do you want to add? (0 to exit)
 (See <https://github.com/r-lib/actions/tree/v2/examples> for other options) 
 


### PR DESCRIPTION
Maybe this is supposed to be `use_github_actions()` rather than`use_github_action()`? When I type `use_github_action()` I get:
```
> use_github_action()
Error in check_string(name) : argument "name" is missing, with no default
```