### PR TITLE
wre links

### DIFF
--- a/data/r-manuals-links.csv
+++ b/data/r-manuals-links.csv
@@ -1,0 +1,12 @@
+manual,slug,quarto,cran
+r-exts,,https://rstudio.github.io/r-manuals/r-exts/,https://cran.r-project.org/doc/manuals/R-exts.html
+r-admin,,https://rstudio.github.io/r-manuals/r-admin/,https://cran.r-project.org/doc/manuals/R-admin.html
+r-exts,creating-r-packages,https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html,https://cran.r-project.org/doc/manuals/R-exts.html#Creating-R-packages
+r-exts,data-in-packages,https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#data-in-packages,https://cran.r-project.org/doc/manuals/R-exts.html#Data-in-packages
+r-admin,managing-libraries,https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#managing-libraries,https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#Managing-libraries
+r-exts,the-description-file,https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#the-description-file,https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file
+r-exts,rd-format,https://rstudio.github.io/r-manuals/r-exts/Writing-R-documentation-files.html#rd-format,https://cran.r-project.org/doc/manuals/R-exts.html#Rd-format
+r-exts,building-package-tarballs,https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#building-package-tarballs,https://cran.r-project.org/doc/manuals/R-exts.html#Building-package-tarballs
+r-exts,building-binary-packages,https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#building-binary-packages,https://cran.r-project.org/doc/manuals/R-exts.html#Building-binary-packages
+r-admin,installing-packages,https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#installing-packages,https://cran.r-project.org/doc/manuals/R-admin.html#Installing-packages
+r-exts,checking-packages,https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#checking-packages,https://cran.r-project.org/doc/manuals/R-exts.html#Checking-packages

--- a/description.Rmd
+++ b/description.Rmd
@@ -472,7 +472,7 @@ We discourage the explicit use of the `Date` field, as it is extremely easy to f
 This field will be populated in the natural course of bundling the package, e.g. when submitting to CRAN, and we recommend that you just let that happen.
 
 There are many other DESCRIPTION fields that are used less frequently.
-A complete list can be found in the "The DESCRIPTION file" section of [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file).
+A complete list can be found in the "The DESCRIPTION file" section of [Writing R Extensions](https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#the-description-file).
 
 ## Custom fields {#sec-description-custom-fields}
 

--- a/introduction.Rmd
+++ b/introduction.Rmd
@@ -77,7 +77,7 @@ However, this manual can be hard to understand if you're not already familiar wi
 It's also exhaustive, covering every possible package component, rather than focusing on the most common and useful components, as this book does.
 Writing R extensions is a useful resource once you've mastered the basics and want to learn what's going on under the hood.
 
-[^introduction-2]: You might also enjoy the "quarto-ized" version at [https://rstudio.github.io/r-manuals/r-exts/](https://rstudio.github.io/r-manuals/r-exts/Function-and-variable-index.html).
+[^introduction-2]: You might also enjoy the "quarto-ized" version at <https://rstudio.github.io/r-manuals/r-exts/>.
 
 ## In this book {#intro-outline}
 

--- a/man.Rmd
+++ b/man.Rmd
@@ -109,7 +109,7 @@ You can also run `devtools::document()` with the keyboard shortcut Ctrl/Cmd + Sh
 :::
 
 If you've used LaTeX before, this should look vaguely familiar since the `.Rd` format is loosely based on LaTeX.
-If you are interested in the `.Rd` format, you can read more in [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html#Rd-format).
+If you are interested in the `.Rd` format, you can read more in [Writing R Extensions](https://rstudio.github.io/r-manuals/r-exts/Writing-R-documentation-files.html#rd-format).
 But generally you'll never need to look at `.Rd` files, except to commit them to your package's Git repository.
 
 How does this `.Rd` file correspond to the documentation you see in R?

--- a/structure.Rmd
+++ b/structure.Rmd
@@ -65,7 +65,7 @@ This means that multiple files have been reduced to a single file (`.tar`) and t
 While a bundle is not that useful on its own, it's a platform-agnostic, transportation-friendly intermediary between a source package and an installed package.
 
 In the rare case that you need to make a bundle from a package you're developing locally, use `devtools::build()`.
-Under the hood, this calls `pkgbuild::build()` and, ultimately, `R CMD build`, which is described further in the [Building package tarballs](https://cran.r-project.org/doc/manuals/R-exts.html#Building-package-tarballs) section of [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html).
+Under the hood, this calls `pkgbuild::build()` and, ultimately, `R CMD build`, which is described further in the [Building package tarballs](https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#building-package-tarballs) section of [Writing R Extensions](https://rstudio.github.io/r-manuals/r-exts/).
 
 This should tip you off that a package bundle or "source tarball" is not simply the result of making a tar archive of the source files, then compressing with gzip.
 By convention, in the R world, a few more operations are carried out when making the `.tar.gz` file and this is why we've elected to refer to this form as a package **bundle**, in this book.
@@ -169,7 +169,7 @@ Unlike a bundled package, a binary package is platform specific and there are tw
 
 Binary packages for macOS are stored as `.tgz`, whereas Windows binary packages end in `.zip`.
 If you need to make a binary package, use `devtools::build(binary = TRUE)` on the relevant operating system.
-Under the hood, this calls `pkgbuild::build(binary = TRUE)` and, ultimately, `R CMD INSTALL --build`, which is described further in the [Building binary packages](https://cran.r-project.org/doc/manuals/R-exts.html#Building-binary-packages) section of [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html).
+Under the hood, this calls `pkgbuild::build(binary = TRUE)` and, ultimately, `R CMD INSTALL --build`, which is described further in the [Building binary packages](https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#building-binary-packages) section of [Writing R Extensions](https://rstudio.github.io/r-manuals/r-exts/).
 If you choose to release your package on CRAN (@sec-release), you submit your package in bundled form, then CRAN creates and distributes the package binaries.
 
 CRAN packages are usually available in binary form, for both macOS and Windows, for the current, previous, and (possibly) development versions of R.
@@ -232,7 +232,7 @@ knitr::include_graphics("diagrams/install-load.png")
 
 The built-in command line tool `R CMD INSTALL` powers all package installation.
 It can install a package from source files, a bundle (a.k.a. a source tarball), or a binary package.
-Details are available in the [Installing packages section](https://cran.r-project.org/doc/manuals/R-admin.html#Installing-packages) of [R Installation and Administration](https://cran.r-project.org/doc/manuals/R-admin.html).
+Details are available in the [Installing packages section](https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#installing-packages) of [R Installation and Administration](https://rstudio.github.io/r-manuals/r-admin/).
 Just like with `devtools::build()`, devtools provides a wrapper function, `devtools::install()`, that makes this tool available from within an R session.
 
 ::: callout-tip

--- a/workflow101.Rmd
+++ b/workflow101.Rmd
@@ -553,4 +553,4 @@ R CMD build somepackage
 R CMD check somepackage_0.0.0.9000.tar.gz  
 ```
 
-To learn more, see the [Checking packages](https://cran.r-project.org/doc/manuals/R-exts.html#Checking-packages) section of [Writing R Extensions](https://cran.r-project.org/doc/manuals/R-exts.html).
+To learn more, see the [Checking packages](https://rstudio.github.io/r-manuals/r-exts/Creating-R-packages.html#checking-packages) section of [Writing R Extensions](https://rstudio.github.io/r-manuals/r-exts/).


### PR DESCRIPTION
I don't know if this is still useful at this point, but I changed all of the links to WRE and R-Admin manuals to the quarto-ized versions. I also included a csv lookup of the links that are used with urls to the quarto version and the cran version.

