### PR TITLE
Fix typo in function name (testthat -> test_that)

### DIFF
--- a/testing-basics.Rmd
+++ b/testing-basics.Rmd
@@ -209,7 +209,7 @@ devtools::load_all()
 # interactively explore and refine expectations and tests
 expect_equal(foofy(...), EXPECTED_FOOFY_OUTPUT)
 
-testthat("foofy does good things", {...})
+test_that("foofy does good things", {...})
 ```
 
 **Mezzo-iteration**: As one file's-worth of functions and their associated tests start to shape up, you will want to execute the entire file of associated tests, perhaps with `testthat::test_file()`:


### PR DESCRIPTION
When I was working through this chapter, I got an error running the code in the micro-iteration section. Seems to be a typo in the function name, for which I propose a fix here.

I assign the copyright of this contribution to Hadley Wickham.