### PR TITLE
Fix example usethis.description option setting

### DIFF
--- a/setup.Rmd
+++ b/setup.Rmd
@@ -79,12 +79,14 @@ Here's an example of a code snippet that could go in `.Rprofile`:
 
 ```{r, eval = FALSE}
 options(
-  usethis.full_name = "Jane Doe",
   usethis.description = list(
-    `Authors@R` = 'person("Jane", "Doe", email = "jane@example.com", role = c("aut", "cre"), 
-    comment = c(ORCID = "YOUR-ORCID-ID"))',
-    License = "MIT + file LICENSE",
-    Version = "0.0.0.9000"
+    "Authors@R" = utils::person(
+      "Jane", "Doe", 
+      email = "jane@example.com", 
+      role = c("aut", "cre"), 
+      comment = c(ORCID = "YOUR-ORCID-ID")
+    ),
+    License = "MIT + file LICENSE"
   )
 )
 ```


### PR DESCRIPTION
* remove usethis.full_name
* remove specification of default version
* reformat code structure

As per https://github.com/r-lib/usethis/issues/1768#issuecomment-1565018599

Fixes #991 