### PR TITLE
missing close parentheses

### DIFF
--- a/testing-design.Rmd
+++ b/testing-design.Rmd
@@ -123,7 +123,7 @@ dat2 <- data.frame(x = c("x", "y", "z"), y = c(4, 5, 6))
 skip_on_os("windows")
 
 test_that("foofy2() does that", {
-  expect_snapshot(foofy2(dat, dat2)
+  expect_snapshot(foofy2(dat, dat2))
 })
 ```
 
@@ -146,7 +146,7 @@ test_that("foofy() does that", {
   dat <- data.frame(x = c("a", "b", "c"), y = c(1, 2, 3))
   dat2 <- data.frame(x = c("x", "y", "z"), y = c(4, 5, 6))
   
-  expect_snapshot(foofy(dat, dat2)
+  expect_snapshot(foofy(dat, dat2))
 })
 ```
 


### PR DESCRIPTION
Thanks the great book.

After coping the two code chunk(`eval = FALSE`) in the Rstudio and it show the following problems, It should miss the close parentheses.
![image](https://github.com/hadley/r-pkgs/assets/98389771/6ead8755-2329-4e22-9724-33c12a95286c)

I assign the copyright of this contribution to Hadley Wickham.