### PR TITLE
Update setup.Rmd: missing comma in options()

### DIFF
--- a/setup.Rmd
+++ b/setup.Rmd
@@ -84,7 +84,7 @@ options(
     email = "jane@example.com",
     role = c("aut", "cre"),
     comment = c(ORCID = "0000-1111-2222-3333")
-  )
+  ),
   License = "MIT + file LICENSE"
 )
 ```


### PR DESCRIPTION
Comma missing from options() example. 

I assign copyright of this update to Hadley Wickham.