### PR TITLE
Change in windows user library location (for R>=4.2)

### DIFF
--- a/structure.Rmd
+++ b/structure.Rmd
@@ -326,7 +326,7 @@ Here's how this might look on Windows:
 ```{r, eval = FALSE}
 # on Windows
 .libPaths()
-#> [1] "C:/Users/jenny/Documents/R/win-library/4.2"
+#> [1] "C:/Users/jenny/AppData/Local/R/win-library/4.2"
 #> [2] "C:/Program Files/R/R-4.2.2/library"
 
 lapply(.libPaths(), list.dirs, recursive = FALSE, full.names = FALSE)


### PR DESCRIPTION
@jennybc 
As discussed in [rstats-wtf](https://github.com/rstats-wtf/what-they-forgot/pull/98), standard for windows user library has changed starting with R4.2, see [PR#17842](https://bugs.r-project.org/show_bug.cgi?id=17842)

Update for path to windows user library, which is (for R>=4.2) located at C:/Users/<username>/AppData/Local/R/win-library/x.y