### PR TITLE
Address NOTE on large version components (issue #1028)

### DIFF
--- a/release.Rmd
+++ b/release.Rmd
@@ -235,6 +235,17 @@ This is meant to be a last-minute, final reminder to double-check that all is st
     Checking with r-devel is required by CRAN policy and it will be done as part of CRAN's incoming checks.
     There is no point in skipping this step and hoping for the best.
 
+When you are preparing to upload a package with a development version (such as in the case when you update a previously released package), both of these will generate at least one `NOTE`:
+
+```
+❯ checking CRAN incoming feasibility ... [5s/35s] NOTE
+  Maintainer: ‘Hadley Wickham <hadley@posit.co>’
+  
+  Version contains large components (1.2.0.9000)
+```
+
+This `NOTE` will be eliminated when you bump the version number (@sec-release-process) so there is no specific action necessary at this time.
+
 Note that the brevity of this list implicitly reflects that tidyverse packages are checked after every push via GitHub Actions, across multiple operating systems and versions of R (including the development version), and that most of the tidyverse team develops primarily on macOS.
 CRAN expects you to "make all reasonable efforts" to get your package working across all of the major R platforms and packages that don't work on at least two will typically not be accepted.
 


### PR DESCRIPTION
This PR inserts a paragraph in section 22.4 to explain that `devtools::check(remote = T, manual = T)` and `devtools::check_win_devel()` will issue a `NOTE` on development versions.

I assign the copyright of this contribution to Hadley Wickham.