### PR TITLE
What they forgot to teach you about R incorrect link fix

### DIFF
--- a/structure.Rmd
+++ b/structure.Rmd
@@ -382,7 +382,7 @@ Above, the macOS system is used as a primary development machine and has many pa
 The core set of base and recommended packages that ship with R live in the system-level library and are the same on all operating systems.
 This separation appeals to many developers and makes it easy to, for example, clean out your add-on packages without disturbing your base R installation.
 
-[^structure-3]: For more details, see the [Maintaining R section](https://rstats.wtf/maintaining-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
+[^structure-3]: For more details, see the [Maintaining R section](https://rstats.wtf/maintaining-r#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
 
 If you're on macOS or Linux and only see one library, there is no urgent need to change anything.
 But next time you upgrade R, consider creating a user-level library.

--- a/structure.Rmd
+++ b/structure.Rmd
@@ -382,7 +382,7 @@ Above, the macOS system is used as a primary development machine and has many pa
 The core set of base and recommended packages that ship with R live in the system-level library and are the same on all operating systems.
 This separation appeals to many developers and makes it easy to, for example, clean out your add-on packages without disturbing your base R installation.
 
-[^structure-3]: For more details, see the [Maintaining R section](https://whattheyforgot.org/maintaining-r.html#how-to-transfer-your-library-when-updating-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
+[^structure-3]: For more details, see the [Maintaining R section](https://rstats.wtf/maintaining-r) in *What They Forgot To Teach You About R*, [Managing Libraries](https://rstudio.github.io/r-manuals/r-admin/Add-on-packages.html#managing-libraries) in *R Installation and Administration* and the R help files for `?Startup` and `?.libPaths`.
 
 If you're on macOS or Linux and only see one library, there is no urgent need to change anything.
 But next time you upgrade R, consider creating a user-level library.


### PR DESCRIPTION
The original link appears to redirect here: https://www.statelocalgov.net/other-zz.cfm#how-to-transfer-your-library-when-updating-r.

![image](https://github.com/hadley/r-pkgs/assets/119683040/df019ec1-1e3b-48d8-955a-270722827702)



Which doesn't seem right.....

The new link is the first result on google for "what they forgot to teach you about r" and I assume the correct link?

![image](https://github.com/hadley/r-pkgs/assets/119683040/748b4f23-9382-4443-946f-d3279bb505b3)
