### PR TITLE
Update lifecycle.Rmd

### DIFF
--- a/lifecycle.Rmd
+++ b/lifecycle.Rmd
@@ -96,7 +96,7 @@ These three different views of usethis's evolution are all useful for different 
 
 Formally, an R package version is a sequence of at least two integers separated by either `.` or `-`.
 For example, `1.0` and `0.9.1-10` are valid versions, but `1` and `1.0-devel` are not.
-Base R offers the `base::package_version()`[^lifecycle-2] function to parse a package version string into a proper S3 class by the same name.
+Base R offers the `package_version()` function to parse a package version string into a proper S3 class by the same name.
 This class makes it easier to do things like compare versions.
 
 [^lifecycle-2]: We can call `package_version()` directly here, but in package code, you should use the `base::package_version()` form and list the base package in `Imports`.

--- a/lifecycle.Rmd
+++ b/lifecycle.Rmd
@@ -99,8 +99,6 @@ For example, `1.0` and `0.9.1-10` are valid versions, but `1` and `1.0-devel` ar
 Base R offers the `package_version()` function to parse a package version string into a proper S3 class by the same name.
 This class makes it easier to do things like compare versions.
 
-[^lifecycle-2]: We can call `package_version()` directly here, but in package code, you should use the `base::package_version()` form and list the base package in `Imports`.
-
 ```{r}
 #| error: true
 package_version(c("1.0", "0.9.1-10"))

--- a/lifecycle.Rmd
+++ b/lifecycle.Rmd
@@ -96,10 +96,10 @@ These three different views of usethis's evolution are all useful for different 
 
 Formally, an R package version is a sequence of at least two integers separated by either `.` or `-`.
 For example, `1.0` and `0.9.1-10` are valid versions, but `1` and `1.0-devel` are not.
-Base R offers the `utils::package_version()`[^lifecycle-2] function to parse a package version string into a proper S3 class by the same name.
+Base R offers the `base::package_version()`[^lifecycle-2] function to parse a package version string into a proper S3 class by the same name.
 This class makes it easier to do things like compare versions.
 
-[^lifecycle-2]: We can call `package_version()` directly here, but in package code, you should use the `utils::package_version()` form and list the utils package in `Imports`.
+[^lifecycle-2]: We can call `package_version()` directly here, but in package code, you should use the `base::package_version()` form and list the base package in `Imports`.
 
 ```{r}
 #| error: true


### PR DESCRIPTION
In [section 21.2](https://r-pkgs.org/lifecycle.html#sec-lifecycle-version-number) it states that the function `package_version()` comes from utils, but I think this is a mistake and is supposed to say that it comes from base.

I've updated the sections of relevant text to reflect this, but now I am not sure the updated footnote indicating that base should be added to imports (previously it said utils should be added) is relevant/required.