### PR TITLE
Solving unmatched crossreference R-CMD-check.Rmd

### DIFF
--- a/R-CMD-check.Rmd
+++ b/R-CMD-check.Rmd
@@ -208,7 +208,7 @@ tools:::.check_package_CRAN_incoming
 
 <!-- https://github.com/wch/r-source/blob/trunk/src/library/tools/R/check.R#L1226 -->
 
--   **Checking R files for non-ASCII characters**. For maximum portability (i.e. so people can use your package on Windows) you should avoid using non-ASCII characters in R files. It's ok to use them in comments, but object names shouldn't use them, and in strings you should use unicode escapes. See the CRAN-specific notes in @sec-code for more details.
+-   **Checking R files for non-ASCII characters**. For maximum portability (i.e. so people can use your package on Windows) you should avoid using non-ASCII characters in R files. It's ok to use them in comments, but object names shouldn't use them, and in strings you should use unicode escapes. See the CRAN-specific notes in @sec-r for more details.
 
 <!-- https://github.com/wch/r-source/blob/trunk/src/library/tools/R/check.R#L1258 -->
 


### PR DESCRIPTION
This commit fixed unresolved cross-reference at appendix `R CMD check` under section "A.5 R Code". Was fixed to point at "Chapter 6 R Code".
Actual reference `@sec-code` is been displayed as follow
![image](https://github.com/hadley/r-pkgs/assets/72680874/6bc0ab5a-05ae-45e0-9c68-165a735075af)
 
To reference "Chapter 6 R Code" was changed to `@sec-r`