### PR TITLE
Typo fix in vignettes.Rmd

### DIFF
--- a/vignettes.Rmd
+++ b/vignettes.Rmd
@@ -436,7 +436,7 @@ However, we acknowledge that there are exceptions to every rule.
 In some domains, it might be impractical to rebuild vignettes as often as our recommended workflow implies.
 Here are a few tips:
 
--   You can prevent the cleaning of `inst/doc/` with `pkgbuild::build(clean_doc =)`.
+-   You can prevent the cleaning of `inst/doc/` with `pkgbuild::build(clean_doc = FALSE)`.
     You can put `Config/build/clean-inst-doc: FALSE` in `DESCRIPTION` to prevent pkgbuild and rcmdcheck from cleaning `inst/doc/`.
 
 -   The rOpenSci tech note [How to precompute package vignettes or pkgdown articles](https://ropensci.org/blog/2019/12/08/precompute-vignettes/) describes a clever, lightweight technique for keeping a manually-updated vignette in `vignettes/`.


### PR DESCRIPTION
Added the missing FALSE to the clean_doc argument on line 439 when discussing preventing the cleaning of `inst/doc/`. I assign the copyright of this contribution to Hadley Wickham.