### PR TITLE
updat r-hub link to unofficial mirror to GH org

### DIFF
--- a/structure.Rmd
+++ b/structure.Rmd
@@ -48,7 +48,7 @@ and one of its URLs links to a repository on a public hosting service, e.g.:
 
 Some maintainers forget to list this URL, even though the package is developed in a public repository, but you still might be able to discover it via search.
 
-Even if a package is not developed on a public platform, you can visit its source in the [unofficial, read-only mirror maintained by R-hub](https://docs.r-hub.io/#cranatgh).
+Even if a package is not developed on a public platform, you can visit its source in the [unofficial, read-only mirror maintained by R-hub](https://github.com/cran).
 Examples:
 
 -   MASS: <https://github.com/cran/MASS>


### PR DESCRIPTION
The original link just now redirects to https://r-hub.github.io/rhub/index.html, I had a bit of a dig around on the pkgdown site, but I couldn't find another link to the mirror