### PR TITLE
fix typo url

### DIFF
--- a/R-CMD-check.Rmd
+++ b/R-CMD-check.Rmd
@@ -12,7 +12,7 @@ This means they will be in a somewhat different order to what you'll see when yo
 
 If this chapter doesn't match up with what you're seeing, consider that the checks may have changed since this was written.
 R continues to evolve, including `R CMD check`.
-You may want to consult the most recent online version of this chapter: <https://r-pkgs.org/r-cmd-check.html>.
+You may want to consult the most recent online version of this chapter: <https://r-pkgs.org/R-CMD-check.html>.
 Please [open an issue](https://github.com/hadley/r-pkgs/issues/new) if you encounter a problem that this chapter doesn't help with.
 
 At the very end (@sec-r-cmd-check-informational-notes), we highlight some NOTEs that arise during `R CMD check` that don't require any response from you.


### PR DESCRIPTION
Hi! 

I was browsing this page: https://r-pkgs.org/R-CMD-check.html

And found that this link at the very top https://r-pkgs.org/r-cmd-check.html is broken because of lowercasing.